### PR TITLE
feat: force update & cache clear on version click

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -4,9 +4,15 @@ import ToastContainer from '@/components/ToastContainer.vue'
 import UpdateBanner from '@/components/UpdateBanner.vue'
 import AutoUpdateNotification from '@/components/AutoUpdateNotification.vue'
 import MigrationProgress from '@/components/MigrationProgress.vue'
+import { getPWAUpdateService } from '@/services/PWAUpdateService'
 
 // App version from build-time injection
 const appVersion = __APP_VERSION__
+
+const forceRefresh = async () => {
+  const updateService = getPWAUpdateService()
+  await updateService.forceUpdateAndClearCache()
+}
 </script>
 
 <template>
@@ -30,7 +36,9 @@ const appVersion = __APP_VERSION__
           >GitHub</a
         >
       </p>
-      <p class="version">OpenStride v{{ appVersion }}</p>
+      <p class="version" @click="forceRefresh" title="Cliquer pour forcer la mise à jour">
+        OpenStride v{{ appVersion }}
+      </p>
     </footer>
   </div>
 </template>
@@ -67,5 +75,9 @@ main {
   font-size: 0.75rem;
   color: #999;
   font-weight: 300;
+  cursor: pointer;
+}
+.footer .version:hover {
+  text-decoration: underline;
 }
 </style>

--- a/src/services/PWAUpdateService.ts
+++ b/src/services/PWAUpdateService.ts
@@ -259,6 +259,31 @@ export class PWAUpdateService {
   public clearDeferredFlag(): void {
     localStorage.removeItem('pwa_update_deferred')
   }
+
+  /**
+   * Force cache clear and reload
+   * Used when user clicks on version in footer
+   */
+  public async forceUpdateAndClearCache(): Promise<void> {
+    console.log('[PWAUpdateService] Force update and cache clear requested')
+
+    // 1. Clear all caches
+    if ('caches' in window) {
+      const cacheNames = await caches.keys()
+      await Promise.all(cacheNames.map(name => caches.delete(name)))
+      console.log(`[PWAUpdateService] Cleared ${cacheNames.length} caches`)
+    }
+
+    // 2. Unregister service workers
+    if ('serviceWorker' in navigator) {
+      const registrations = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(registrations.map(r => r.unregister()))
+      console.log(`[PWAUpdateService] Unregistered ${registrations.length} service workers`)
+    }
+
+    // 3. Force reload (bypass cache)
+    window.location.reload()
+  }
 }
 
 // Export singleton getter


### PR DESCRIPTION
## Summary
- Click on version in footer to force cache clear and reload
- Adds `forceUpdateAndClearCache()` method to PWAUpdateService
- Clears all caches, unregisters service workers, then reloads

## Test plan
- [ ] Build production version (`npm run build && npm run preview`)
- [ ] Open DevTools → Application → Cache Storage (noter les caches)
- [ ] Click on "OpenStride v0.4.0" in footer
- [ ] Verify caches are cleared and page reloads
- [ ] Verify SW re-registers correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)