### PR TITLE
fix(garmin): fix refresh not triggering and auto-refresh activity list

### DIFF
--- a/plugins/app-extensions/StandardDetails/SpeedSampled.vue
+++ b/plugins/app-extensions/StandardDetails/SpeedSampled.vue
@@ -169,7 +169,7 @@ function drawCanvas() {
   let minSpeed = Math.min(...speeds)
   let maxSpeed = Math.max(...speeds)
 
-  let treshold = 0.1 * (maxSpeed - minSpeed || 1);
+  const treshold = 0.1 * (maxSpeed - minSpeed || 1);
   minSpeed = Math.max(minSpeed - treshold, 0);
   maxSpeed = Math.max(maxSpeed + treshold, minSpeed + 0.1);
 

--- a/plugins/storage-providers/GDrive/client/GoogleDriveAuthService.ts
+++ b/plugins/storage-providers/GDrive/client/GoogleDriveAuthService.ts
@@ -122,17 +122,17 @@ export class GoogleDriveAuthService {
     }
 
     async getOauthSignInUri(): Promise<string | null> {
-        var state = generateRandomString();
+        const state = generateRandomString();
         localStorage.setItem("pkce_state", state);
 
         // Create and store a new PKCE code_verifier (the plaintext random secret)
-        var code_verifier = generateRandomString();
+        const code_verifier = generateRandomString();
         localStorage.setItem("pkce_code_verifier", code_verifier);
 
         // Hash and base64-urlencode the secret to use as the challenge
-        var code_challenge = await generateCodeChallenge(code_verifier);
+        const code_challenge = await generateCodeChallenge(code_verifier);
         console.log("redirect_uri", `${window.location.origin}${window.location.pathname}`);
-        var url = AUTHORIZATION_ENDPOINT
+        const url = AUTHORIZATION_ENDPOINT
             + "?response_type=code"
             + "&client_id=" + encodeURIComponent(CLIENT_ID)
             + "&state=" + encodeURIComponent(state)

--- a/src/services/ActivityAnalyzer.ts
+++ b/src/services/ActivityAnalyzer.ts
@@ -71,8 +71,8 @@ export class ActivityAnalyzer {
   private classifyByAccumulatedSlope(samples: Sample[]): 'up' | 'down' | 'flat' {
     let gain = 0
     let loss = 0
-    let startDist = samples[0]?.distance ?? 0
-    let endDist = samples.at(-1)?.distance ?? startDist
+    const startDist = samples[0]?.distance ?? 0
+    const endDist = samples.at(-1)?.distance ?? startDist
     for (let i = 1; i < samples.length; i++) {
       const prev = samples[i - 1].elevation
       const curr = samples[i].elevation

--- a/src/services/FriendService.ts
+++ b/src/services/FriendService.ts
@@ -281,7 +281,7 @@ export class FriendService {
    */
   private async fetchRecentActivities(
     manifest: PublicManifest,
-    limit: number = 30
+    limit = 30
   ): Promise<any[]> {
     console.log(`[FriendService] Fetching ${limit} most recent activities`)
 
@@ -558,7 +558,7 @@ export class FriendService {
    */
   public async syncFriendActivitiesQuick(
     friendId: string,
-    limit: number = 30
+    limit = 30
   ): Promise<FriendSyncResult> {
     const startTime = performance.now()
     console.log(`[FriendService] Quick sync for friend ${friendId} (${limit} activities)`)

--- a/src/services/GoogleDriveApiService.ts
+++ b/src/services/GoogleDriveApiService.ts
@@ -16,7 +16,7 @@ declare global {
 
 export class GoogleDriveApiService {
   private static instance: GoogleDriveApiService
-  private initialized: boolean = false
+  private initialized = false
   private initPromise: Promise<void> | null = null
   private apiKey: string
 

--- a/src/services/MigrationService.ts
+++ b/src/services/MigrationService.ts
@@ -120,7 +120,7 @@ export class MigrationService {
     )
 
     // Get or initialize migration history
-    let history: MigrationRecord[] = (await db.getData('migration_history')) || []
+    const history: MigrationRecord[] = (await db.getData('migration_history')) || []
 
     for (let i = 0; i < pending.length; i++) {
       const migration = pending[i]

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -16,6 +16,10 @@ import {
 
 declare const self: ServiceWorkerGlobalScope
 
+// Version is injected by Vite define, fallback for dev mode
+declare const __APP_VERSION__: string | undefined
+const APP_VERSION = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'
+
 // ========================================
 // 1. Workbox Setup (PWA Caching)
 // ========================================
@@ -77,13 +81,13 @@ if (messaging) {
 // ========================================
 
 self.addEventListener('install', event => {
-  console.log('[Service Worker] Installing version', __APP_VERSION__)
+  console.log('[Service Worker] Installing version', APP_VERSION)
   // Prompt mode: wait for user consent via messageSkipWaiting()
   // skipWaiting() will be called via message handler when user accepts update
 })
 
 self.addEventListener('activate', event => {
-  console.log('[Service Worker] Activating version', __APP_VERSION__)
+  console.log('[Service Worker] Activating version', APP_VERSION)
   event.waitUntil(self.clients.claim()) // Take control immediately
 })
 

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -1,4 +1,4 @@
-/* eslint-disable arrow-body-style */
+ 
 // https://docs.cypress.io/guides/guides/plugins-guide.html
 
 // if you need a custom webpack configuration you can uncomment the following import

--- a/tests/fixtures/activities.ts
+++ b/tests/fixtures/activities.ts
@@ -12,7 +12,7 @@ const BASE_TIME = new Date('2026-01-15T08:00:00Z').getTime()
 /**
  * Sample GPS points simulating a 5km run in Paris
  */
-export const createSampleGPSTrack = (numPoints: number = 100): Sample[] => {
+export const createSampleGPSTrack = (numPoints = 100): Sample[] => {
   const samples: Sample[] = []
   const startLat = 48.8566 // Paris center
   const startLng = 2.3522
@@ -63,8 +63,8 @@ export const createActivity = (overrides?: Partial<Activity>): Activity => ({
  * Create activity details with samples
  */
 export const createActivityDetails = (
-  activityId: string = 'activity-1',
-  numSamples: number = 100,
+  activityId = 'activity-1',
+  numSamples = 100,
   overrides?: Partial<ActivityDetails>
 ): ActivityDetails => ({
   id: activityId,
@@ -199,8 +199,8 @@ export const createPrivateActivity = (overrides?: Partial<Activity>): Activity =
  * Create a friend's public activity (FriendActivity type)
  */
 export const createFriendActivity = (
-  friendId: string = 'friend-1',
-  activityId: string = 'activity-1',
+  friendId = 'friend-1',
+  activityId = 'activity-1',
   overrides?: Partial<FriendActivity>
 ): FriendActivity => ({
   id: `${friendId}_${activityId}_2026`,
@@ -274,7 +274,7 @@ export const createPublicActivity = (overrides?: Partial<PublicActivity>): Publi
 /**
  * Create year activities collection
  */
-export const createYearActivities = (year: number = 2026, count: number = 10): YearActivities => ({
+export const createYearActivities = (year = 2026, count = 10): YearActivities => ({
   year,
   activities: Array.from({ length: count }, (_, i) =>
     createPublicActivity({

--- a/tests/unit/ActivityAnalyzer.slope.spec.ts
+++ b/tests/unit/ActivityAnalyzer.slope.spec.ts
@@ -6,7 +6,7 @@ function buildSegment(startDist: number, length: number, slopePct: number, start
   const out: Sample[] = []
   const metersPerSample = step
   const elevPerMeter = slopePct / 100
-  let timeOffset = startDist / speed
+  const timeOffset = startDist / speed
   for (let d = 0; d <= length; d += metersPerSample) {
     const distance = startDist + d
     const elevation = startElev + d * elevPerMeter

--- a/tests/unit/ActivityService.spec.ts
+++ b/tests/unit/ActivityService.spec.ts
@@ -295,7 +295,7 @@ describe('ActivityService', () => {
 
       // Manually mark as synced
       await service.markAsSynced(['test-1'])
-      let synced = await service.getActivity('test-1')
+      const synced = await service.getActivity('test-1')
       expect(synced!.synced).toBe(true)
 
       await service.updateActivity('test-1', { title: 'Updated' })


### PR DESCRIPTION
## Summary
- **Garmin OAuth**: enable plugin automatically after OAuth callback so `triggerRefresh()` includes it
- **Garmin 24h API limit**: fetch last 7 days day-by-day instead of one big range (API rejects >24h)
- **MyActivities auto-refresh**: listen to `activity-changed` events with debounce to refresh the list when activities are imported
- **Service Worker**: fix `__APP_VERSION__` declaration with dev fallback
- **Lint cleanup**: `var`/`let` → `const`, remove redundant type annotations on default params

## Test plan
- [ ] Connect Garmin via OAuth → plugin should be enabled and refresh should fetch activities
- [ ] Import activities → MyActivities list refreshes automatically without manual reload
- [ ] Verify service worker installs correctly in production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)