### PR TITLE
feat: add statistics plugin

### DIFF
--- a/plugins/app-extensions/Statistics/components/CalendarHeatmap.vue
+++ b/plugins/app-extensions/Statistics/components/CalendarHeatmap.vue
@@ -1,0 +1,397 @@
+<template>
+  <section class="section-card">
+    <h3 class="section-title">
+      <i class="fas fa-calendar-alt" aria-hidden="true"></i>
+      {{ t('statistics.heatmap.title') }}
+    </h3>
+
+    <div class="heatmap-controls">
+      <button
+        v-for="m in metrics"
+        :key="m"
+        :class="['toggle-btn', { active: metric === m }]"
+        @click="metric = m"
+      >
+        {{ t(`statistics.heatmap.${m}`) }}
+      </button>
+    </div>
+
+    <div class="heatmap-layout">
+      <div class="heatmap-days">
+        <div class="day-spacer"></div>
+        <div class="day-grid">
+          <span class="day-label" :style="{ gridRow: 1 }"></span>
+          <span class="day-label" :style="{ gridRow: 2 }">{{ dayLabels[1] }}</span>
+          <span class="day-label" :style="{ gridRow: 3 }"></span>
+          <span class="day-label" :style="{ gridRow: 4 }">{{ dayLabels[3] }}</span>
+          <span class="day-label" :style="{ gridRow: 5 }"></span>
+          <span class="day-label" :style="{ gridRow: 6 }">{{ dayLabels[5] }}</span>
+          <span class="day-label" :style="{ gridRow: 7 }"></span>
+        </div>
+      </div>
+      <div ref="scrollArea" class="heatmap-scroll">
+        <div class="heatmap-inner" :style="{ width: totalWeeks * 14 + 'px' }">
+          <div
+            class="heatmap-months"
+            :style="{ gridTemplateColumns: `repeat(${totalWeeks}, 12px)` }"
+          >
+            <span
+              v-for="(ml, idx) in monthPositions"
+              :key="idx"
+              class="month-label"
+              :style="{ gridColumn: ml.col }"
+              >{{ ml.label }}</span
+            >
+          </div>
+          <div class="heatmap-grid" :style="{ gridTemplateColumns: `repeat(${totalWeeks}, 12px)` }">
+            <div
+              v-for="(cell, i) in cells"
+              :key="i"
+              :class="['heatmap-cell', `level-${cell.level}`]"
+              :title="cell.tooltip"
+              :style="{ gridRow: cell.row, gridColumn: cell.col }"
+            ></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="heatmap-legend">
+      <span class="legend-label">{{ t('statistics.heatmap.less') }}</span>
+      <div class="heatmap-cell level-0"></div>
+      <div class="heatmap-cell level-1"></div>
+      <div class="heatmap-cell level-2"></div>
+      <div class="heatmap-cell level-3"></div>
+      <div class="heatmap-cell level-4"></div>
+      <span class="legend-label">{{ t('statistics.heatmap.more') }}</span>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { Activity } from '@/types/activity'
+import { toMs } from '../types'
+import type { HeatmapMetric } from '../types'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  activities: Activity[]
+}>()
+
+const metrics: HeatmapMetric[] = ['distance', 'duration', 'count']
+const metric = ref<HeatmapMetric>('distance')
+const dayLabels = ['D', 'L', 'M', 'M', 'J', 'V', 'S']
+const scrollArea = ref<HTMLElement | null>(null)
+
+function scrollToEnd() {
+  nextTick(() => {
+    if (scrollArea.value) {
+      scrollArea.value.scrollLeft = scrollArea.value.scrollWidth
+    }
+  })
+}
+
+onMounted(scrollToEnd)
+watch(() => props.activities, scrollToEnd)
+
+function toDayKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
+const dayData = computed(() => {
+  const map = new Map<string, { distance: number; duration: number; count: number }>()
+  for (const a of props.activities) {
+    const key = toDayKey(new Date(toMs(a.startTime)))
+    const existing = map.get(key)
+    if (existing) {
+      existing.distance += (a.distance || 0) / 1000
+      existing.duration += (a.duration || 0) / 3600
+      existing.count++
+    } else {
+      map.set(key, {
+        distance: (a.distance || 0) / 1000,
+        duration: (a.duration || 0) / 3600,
+        count: 1
+      })
+    }
+  }
+  return map
+})
+
+function getStartDate(): Date {
+  const d = new Date()
+  d.setFullYear(d.getFullYear() - 1)
+  d.setDate(d.getDate() + 1)
+  const day = d.getDay()
+  const diff = day === 0 ? 6 : day - 1
+  d.setDate(d.getDate() - diff)
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+const monthNames = [
+  'Jan',
+  'Fev',
+  'Mar',
+  'Avr',
+  'Mai',
+  'Jun',
+  'Jul',
+  'Aou',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec'
+]
+
+const monthPositions = computed(() => {
+  const start = getStartDate()
+  const positions: { label: string; col: number }[] = []
+  let lastMonth = -1
+  for (let w = 0; w < 53; w++) {
+    const d = new Date(start)
+    d.setDate(d.getDate() + w * 7)
+    if (d.getMonth() !== lastMonth) {
+      positions.push({ label: monthNames[d.getMonth()], col: w + 1 })
+      lastMonth = d.getMonth()
+    }
+  }
+  return positions
+})
+
+const totalWeeks = computed(() => {
+  const start = getStartDate()
+  const today = new Date()
+  const diffDays = Math.ceil((today.getTime() - start.getTime()) / 86400000)
+  return Math.ceil(diffDays / 7) + 1
+})
+
+const cells = computed(() => {
+  const start = getStartDate()
+  const today = new Date()
+  today.setHours(23, 59, 59, 999)
+
+  const allCells: { row: number; col: number; level: number; tooltip: string }[] = []
+  const values: number[] = []
+  const dayEntries: { key: string; row: number; col: number; value: number }[] = []
+  const d = new Date(start)
+
+  let col = 1
+  while (d <= today) {
+    const dayOfWeek = d.getDay()
+    const row = dayOfWeek === 0 ? 7 : dayOfWeek
+    const key = toDayKey(d)
+    const data = dayData.value.get(key)
+    let value = 0
+    if (data) {
+      if (metric.value === 'distance') value = data.distance
+      else if (metric.value === 'duration') value = data.duration
+      else value = data.count
+    }
+    dayEntries.push({ key, row, col, value })
+    if (value > 0) values.push(value)
+
+    d.setDate(d.getDate() + 1)
+    if (d.getDay() === 1) col++
+  }
+
+  if (values.length === 0) {
+    return dayEntries.map(e => ({
+      row: e.row,
+      col: e.col,
+      level: 0,
+      tooltip: e.key
+    }))
+  }
+
+  values.sort((a, b) => a - b)
+  const q1 = values[Math.floor(values.length * 0.25)]
+  const q2 = values[Math.floor(values.length * 0.5)]
+  const q3 = values[Math.floor(values.length * 0.75)]
+
+  function getLevel(v: number): number {
+    if (v === 0) return 0
+    if (v <= q1) return 1
+    if (v <= q2) return 2
+    if (v <= q3) return 3
+    return 4
+  }
+
+  for (const e of dayEntries) {
+    const data = dayData.value.get(e.key)
+    let tooltip = e.key
+    if (data) {
+      if (metric.value === 'distance')
+        tooltip = `${e.key}: ${Math.round(data.distance * 10) / 10} km`
+      else if (metric.value === 'duration')
+        tooltip = `${e.key}: ${Math.round(data.duration * 10) / 10} h`
+      else tooltip = `${e.key}: ${data.count} activite(s)`
+    }
+    allCells.push({
+      row: e.row,
+      col: e.col,
+      level: getLevel(e.value),
+      tooltip
+    })
+  }
+
+  return allCells
+})
+</script>
+
+<style scoped>
+.section-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 1.2rem 1.4rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-title i {
+  color: var(--color-green-500);
+}
+
+.heatmap-controls {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.toggle-btn {
+  padding: 0.3rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-green-200);
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s;
+  font-family: var(--font-main);
+}
+
+.toggle-btn.active {
+  background: var(--color-green-500);
+  color: #fff;
+  border-color: var(--color-green-500);
+}
+
+.heatmap-layout {
+  display: flex;
+  gap: 4px;
+}
+
+.heatmap-days {
+  flex-shrink: 0;
+  width: 18px;
+}
+
+.day-spacer {
+  height: 16px;
+}
+
+.day-grid {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  gap: 2px;
+}
+
+.day-label {
+  font-size: 0.6rem;
+  color: var(--text-color);
+  opacity: 0.6;
+  line-height: 12px;
+}
+
+.heatmap-scroll {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.heatmap-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.heatmap-inner {
+  min-width: fit-content;
+}
+
+.heatmap-months {
+  display: grid;
+  gap: 2px;
+  height: 14px;
+  margin-bottom: 2px;
+}
+
+.month-label {
+  font-size: 0.6rem;
+  color: var(--text-color);
+  opacity: 0.6;
+  white-space: nowrap;
+  line-height: 14px;
+}
+
+.heatmap-grid {
+  display: grid;
+  grid-template-rows: repeat(7, 12px);
+  gap: 2px;
+}
+
+.heatmap-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.level-0 {
+  background: #ebedf0;
+}
+.level-1 {
+  background: var(--color-green-100);
+}
+.level-2 {
+  background: var(--color-green-300);
+}
+.level-3 {
+  background: var(--color-green-500);
+}
+.level-4 {
+  background: var(--color-green-700);
+}
+
+.heatmap-legend {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  justify-content: flex-end;
+  margin-top: 0.8rem;
+}
+
+.heatmap-legend .heatmap-cell {
+  width: 10px;
+  height: 10px;
+}
+
+.legend-label {
+  font-size: 0.7rem;
+  color: var(--text-color);
+  opacity: 0.6;
+  margin: 0 4px;
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/DistributionSection.vue
+++ b/plugins/app-extensions/Statistics/components/DistributionSection.vue
@@ -1,0 +1,305 @@
+<template>
+  <section class="section-card">
+    <h3 class="section-title">
+      <i class="fas fa-chart-pie" aria-hidden="true"></i>
+      {{ t('statistics.distribution.title') }}
+    </h3>
+
+    <div v-if="activities.length === 0" class="empty-chart">
+      {{ t('statistics.noData') }}
+    </div>
+
+    <template v-else-if="!selectedSport">
+      <div class="distribution-grid">
+        <div class="chart-container chart-doughnut">
+          <canvas ref="doughnutCanvas"></canvas>
+        </div>
+        <div class="chart-container chart-bar">
+          <canvas ref="distanceCanvas"></canvas>
+        </div>
+        <div class="chart-container chart-bar">
+          <canvas ref="durationCanvas"></canvas>
+        </div>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="chart-container chart-bar-single">
+        <canvas ref="monthlyCanvas"></canvas>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Chart from 'chart.js/auto'
+import type { Activity } from '@/types/activity'
+import { formatSportType } from '@plugins/app-extensions/Goals/sportLabels'
+import { getMonthKey } from '@/services/AggregationService'
+import { toMs } from '../types'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  activities: Activity[]
+  allActivities: Activity[]
+  selectedSport: string
+}>()
+
+const doughnutCanvas = ref<HTMLCanvasElement | null>(null)
+const distanceCanvas = ref<HTMLCanvasElement | null>(null)
+const durationCanvas = ref<HTMLCanvasElement | null>(null)
+const monthlyCanvas = ref<HTMLCanvasElement | null>(null)
+
+let doughnutChart: Chart | null = null
+let distanceChart: Chart | null = null
+let durationChart: Chart | null = null
+let monthlyChart: Chart | null = null
+
+const sportColors = [
+  '#88aa00',
+  '#e06c00',
+  '#0077b6',
+  '#9b59b6',
+  '#e74c3c',
+  '#1abc9c',
+  '#f39c12',
+  '#34495e',
+  '#e91e63',
+  '#00bcd4'
+]
+
+function getSportData(activities: Activity[]) {
+  const map = new Map<string, { count: number; distance: number; duration: number }>()
+  for (const a of activities) {
+    const sport = (a.type || 'other').toLowerCase()
+    const existing = map.get(sport)
+    if (existing) {
+      existing.count++
+      existing.distance += (a.distance || 0) / 1000
+      existing.duration += (a.duration || 0) / 3600
+    } else {
+      map.set(sport, {
+        count: 1,
+        distance: (a.distance || 0) / 1000,
+        duration: (a.duration || 0) / 3600
+      })
+    }
+  }
+  const entries = Array.from(map.entries()).sort((a, b) => b[1].count - a[1].count)
+  return {
+    labels: entries.map(([s]) => formatSportType(s)),
+    counts: entries.map(([, d]) => d.count),
+    distances: entries.map(([, d]) => Math.round(d.distance * 10) / 10),
+    durations: entries.map(([, d]) => Math.round(d.duration * 10) / 10),
+    colors: entries.map((_, i) => sportColors[i % sportColors.length])
+  }
+}
+
+function getMonthlyData(activities: Activity[]) {
+  const map = new Map<string, number>()
+  for (const a of activities) {
+    const key = getMonthKey(new Date(toMs(a.startTime)))
+    map.set(key, (map.get(key) || 0) + (a.distance || 0) / 1000)
+  }
+  const sorted = Array.from(map.entries()).sort((a, b) => a[0].localeCompare(b[0]))
+  return {
+    labels: sorted.map(([k]) => {
+      const parts = k.split('-')
+      return `${parts[1]}/${parts[0].slice(2)}`
+    }),
+    distances: sorted.map(([, v]) => Math.round(v * 10) / 10)
+  }
+}
+
+function destroyAllCharts() {
+  doughnutChart?.destroy()
+  doughnutChart = null
+  distanceChart?.destroy()
+  distanceChart = null
+  durationChart?.destroy()
+  durationChart = null
+  monthlyChart?.destroy()
+  monthlyChart = null
+}
+
+function createSportCharts() {
+  const data = getSportData(props.allActivities)
+  if (data.labels.length === 0) return
+
+  if (doughnutCanvas.value) {
+    doughnutChart = new Chart(doughnutCanvas.value, {
+      type: 'doughnut',
+      data: {
+        labels: data.labels,
+        datasets: [{ data: data.counts, backgroundColor: data.colors, borderWidth: 0 }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { position: 'bottom', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } }
+        }
+      }
+    })
+  }
+
+  if (distanceCanvas.value) {
+    distanceChart = new Chart(distanceCanvas.value, {
+      type: 'bar',
+      data: {
+        labels: data.labels,
+        datasets: [
+          {
+            label: t('statistics.distribution.distanceKm'),
+            data: data.distances,
+            backgroundColor: data.colors,
+            borderRadius: 4
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y',
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true } }
+      }
+    })
+  }
+
+  if (durationCanvas.value) {
+    durationChart = new Chart(durationCanvas.value, {
+      type: 'bar',
+      data: {
+        labels: data.labels,
+        datasets: [
+          {
+            label: t('statistics.distribution.durationH'),
+            data: data.durations,
+            backgroundColor: data.colors,
+            borderRadius: 4
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        indexAxis: 'y',
+        plugins: { legend: { display: false } },
+        scales: { x: { beginAtZero: true } }
+      }
+    })
+  }
+}
+
+function createMonthlyChart() {
+  const data = getMonthlyData(props.activities)
+  if (data.labels.length === 0 || !monthlyCanvas.value) return
+
+  const style = getComputedStyle(document.documentElement)
+  const green500 = style.getPropertyValue('--color-green-500').trim() || '#88aa00'
+
+  monthlyChart = new Chart(monthlyCanvas.value, {
+    type: 'bar',
+    data: {
+      labels: data.labels,
+      datasets: [
+        {
+          label: t('statistics.distribution.distanceKm'),
+          data: data.distances,
+          backgroundColor: green500,
+          borderRadius: 4
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false } },
+        y: { beginAtZero: true }
+      }
+    }
+  })
+}
+
+async function render() {
+  await nextTick()
+  destroyAllCharts()
+  await nextTick()
+  if (props.selectedSport) {
+    createMonthlyChart()
+  } else {
+    createSportCharts()
+  }
+}
+
+watch([() => props.activities, () => props.selectedSport, () => props.allActivities], render)
+
+onMounted(render)
+onUnmounted(destroyAllCharts)
+</script>
+
+<style scoped>
+.section-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 1.2rem 1.4rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-title i {
+  color: var(--color-green-500);
+}
+
+.distribution-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.chart-doughnut {
+  grid-column: 1 / -1;
+  height: 260px;
+}
+
+.chart-bar {
+  height: 200px;
+}
+
+.chart-bar-single {
+  height: 260px;
+}
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.empty-chart {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-color);
+  opacity: 0.6;
+}
+
+@media (max-width: 640px) {
+  .distribution-grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/PersonalRecordsSection.vue
+++ b/plugins/app-extensions/Statistics/components/PersonalRecordsSection.vue
@@ -1,0 +1,208 @@
+<template>
+  <section class="section-card">
+    <h3 class="section-title">
+      <i class="fas fa-trophy" aria-hidden="true"></i>
+      {{ t('statistics.records.title') }}
+    </h3>
+
+    <div v-if="computing" class="computing">
+      <div class="progress-bar">
+        <div class="progress-fill" :style="{ width: progress + '%' }"></div>
+      </div>
+      <p class="computing-text">{{ t('statistics.records.computing') }} {{ progress }}%</p>
+    </div>
+
+    <div v-else-if="records.length === 0" class="empty-records">
+      <p>{{ t('statistics.records.noRecords') }}</p>
+      <p class="hint">{{ t('statistics.records.noRecordsHint') }}</p>
+    </div>
+
+    <div v-else class="records-table-wrapper">
+      <table class="records-table">
+        <thead>
+          <tr>
+            <th>{{ t('statistics.records.distance') }}</th>
+            <th>{{ t('statistics.records.time') }}</th>
+            <th>{{ t('statistics.records.pace') }}</th>
+            <th class="hide-mobile">{{ t('statistics.records.speed') }}</th>
+            <th>{{ t('statistics.records.date') }}</th>
+            <th class="hide-mobile"></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="r in records" :key="r.distance">
+            <td class="distance-cell">{{ r.distanceLabel }}</td>
+            <td>{{ formatDuration(r.duration) }}</td>
+            <td>{{ formatPace(r.pace) }}</td>
+            <td class="hide-mobile">{{ formatSpeed(r.speed) }}</td>
+            <td>{{ formatDate(r.date) }}</td>
+            <td class="hide-mobile">
+              <router-link :to="`/activity-details/${r.activityId}`" class="view-link">
+                <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+              </router-link>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { toRef } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { Activity } from '@/types/activity'
+import { usePersonalRecords } from '../composables/usePersonalRecords'
+import { toMs } from '../types'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  activities: Activity[]
+  selectedSport: string
+}>()
+
+const { records, computing, progress } = usePersonalRecords(
+  toRef(props, 'activities'),
+  toRef(props, 'selectedSport')
+)
+
+function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  if (h > 0) return `${h}h${String(m).padStart(2, '0')}'${String(s).padStart(2, '0')}"`
+  return `${m}'${String(s).padStart(2, '0')}"`
+}
+
+function formatPace(minPerKm: number): string {
+  const m = Math.floor(minPerKm)
+  const s = Math.round((minPerKm - m) * 60)
+  return `${m}'${String(s).padStart(2, '0')}"/km`
+}
+
+function formatSpeed(kmh: number): string {
+  return `${kmh.toFixed(1)} km/h`
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(toMs(timestamp)).toLocaleDateString()
+}
+</script>
+
+<style scoped>
+.section-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 1.2rem 1.4rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-title i {
+  color: var(--color-green-500);
+}
+
+.computing {
+  padding: 1rem 0;
+}
+
+.progress-bar {
+  height: 6px;
+  background: var(--color-green-100);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--color-green-500);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.computing-text {
+  font-size: 0.85rem;
+  color: var(--text-color);
+  opacity: 0.7;
+  text-align: center;
+  margin: 0;
+}
+
+.empty-records {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--text-color);
+}
+
+.empty-records .hint {
+  font-size: 0.85rem;
+  opacity: 0.6;
+  margin-top: 0.3rem;
+}
+
+.records-table-wrapper {
+  overflow-x: auto;
+}
+
+.records-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.records-table th {
+  text-align: left;
+  padding: 0.5rem 0.6rem;
+  border-bottom: 2px solid var(--color-green-200);
+  color: var(--text-color);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.records-table td {
+  padding: 0.5rem 0.6rem;
+  border-bottom: 1px solid #eee;
+  color: var(--text-color);
+  white-space: nowrap;
+}
+
+.distance-cell {
+  font-weight: 600;
+  color: var(--color-green-600);
+}
+
+.view-link {
+  color: var(--color-green-500);
+  text-decoration: none;
+}
+
+.view-link:hover {
+  color: var(--color-green-700);
+}
+
+@media (max-width: 640px) {
+  .hide-mobile {
+    display: none;
+  }
+
+  .records-table {
+    font-size: 0.8rem;
+  }
+
+  .records-table th,
+  .records-table td {
+    padding: 0.4rem;
+  }
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/SportFilter.vue
+++ b/plugins/app-extensions/Statistics/components/SportFilter.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="sport-filter">
+    <button
+      :class="['filter-btn', { active: !modelValue }]"
+      @click="$emit('update:modelValue', '')"
+    >
+      {{ t('statistics.allSports') }}
+    </button>
+    <button
+      v-for="sport in options"
+      :key="sport.value"
+      :class="['filter-btn', { active: modelValue === sport.value }]"
+      @click="$emit('update:modelValue', sport.value)"
+    >
+      {{ sport.label }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+defineProps<{
+  modelValue: string
+  options: { value: string; label: string }[]
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+</script>
+
+<style scoped>
+.sport-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.filter-btn {
+  padding: 0.4rem 0.9rem;
+  border-radius: 20px;
+  border: 1px solid var(--color-green-200);
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s,
+    border-color 0.2s;
+  font-family: var(--font-main);
+}
+
+.filter-btn:hover {
+  border-color: var(--color-green-400);
+}
+
+.filter-btn.active {
+  background: var(--color-green-500);
+  color: #fff;
+  border-color: var(--color-green-500);
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/StatisticsNavLink.vue
+++ b/plugins/app-extensions/Statistics/components/StatisticsNavLink.vue
@@ -1,0 +1,15 @@
+<template>
+  <router-link to="/statistics" @click="$emit('navigate')">{{
+    t('navigation.statistics')
+  }}</router-link>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+
+defineEmits<{
+  navigate: []
+}>()
+</script>

--- a/plugins/app-extensions/Statistics/components/StatisticsView.vue
+++ b/plugins/app-extensions/Statistics/components/StatisticsView.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="statistics-page">
+    <div class="statistics-header">
+      <h2 class="statistics-title">
+        <i class="fas fa-chart-bar" aria-hidden="true"></i>
+        {{ t('statistics.title') }}
+      </h2>
+      <SportFilter v-if="sportOptions.length > 1" v-model="selectedSport" :options="sportOptions" />
+    </div>
+
+    <div v-if="loading" class="statistics-loading">
+      <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+      {{ t('common.loading') }}
+    </div>
+
+    <div v-else-if="allActivities.length === 0" class="statistics-empty">
+      <i class="fas fa-chart-line" aria-hidden="true"></i>
+      <p>{{ t('statistics.noData') }}</p>
+      <p class="hint">{{ t('statistics.noDataHint') }}</p>
+    </div>
+
+    <div v-else class="statistics-sections">
+      <CalendarHeatmap :activities="filteredActivities" />
+      <TrendsSection :activities="filteredActivities" />
+      <DistributionSection
+        :activities="filteredActivities"
+        :all-activities="allActivities"
+        :selected-sport="selectedSport"
+      />
+      <PersonalRecordsSection :activities="filteredActivities" :selected-sport="selectedSport" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { useStatisticsData } from '../composables/useStatisticsData'
+import SportFilter from './SportFilter.vue'
+import TrendsSection from './TrendsSection.vue'
+import DistributionSection from './DistributionSection.vue'
+import PersonalRecordsSection from './PersonalRecordsSection.vue'
+import CalendarHeatmap from './CalendarHeatmap.vue'
+
+const { t } = useI18n()
+const { allActivities, filteredActivities, selectedSport, sportOptions, loading } =
+  useStatisticsData()
+</script>
+
+<style scoped>
+.statistics-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.statistics-header {
+  margin-bottom: 1.5rem;
+}
+
+.statistics-title {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text-color);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.statistics-title i {
+  color: var(--color-green-500);
+}
+
+.statistics-loading {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-color);
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.statistics-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: var(--text-color);
+}
+
+.statistics-empty i {
+  font-size: 2.5rem;
+  color: var(--color-green-300);
+  margin-bottom: 1rem;
+}
+
+.statistics-empty p {
+  margin: 0.3rem 0;
+}
+
+.statistics-empty .hint {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.statistics-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/TrendsSection.vue
+++ b/plugins/app-extensions/Statistics/components/TrendsSection.vue
@@ -1,0 +1,272 @@
+<template>
+  <section class="section-card">
+    <h3 class="section-title">
+      <i class="fas fa-chart-line" aria-hidden="true"></i>
+      {{ t('statistics.trends.title') }}
+    </h3>
+
+    <div class="period-toggle">
+      <button
+        v-for="g in granularities"
+        :key="g"
+        :class="['toggle-btn', { active: granularity === g }]"
+        @click="granularity = g"
+      >
+        {{ t(`statistics.trends.${g}`) }}
+      </button>
+    </div>
+
+    <div v-if="periodData.length === 0" class="empty-chart">
+      {{ t('statistics.noData') }}
+    </div>
+    <template v-else>
+      <div class="chart-container">
+        <canvas ref="distanceCanvas"></canvas>
+      </div>
+      <div class="chart-container">
+        <canvas ref="countCanvas"></canvas>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Chart from 'chart.js/auto'
+import type { Activity } from '@/types/activity'
+import { toMs } from '../types'
+import type { PeriodGranularity, PeriodData } from '../types'
+import { getISOWeekKey, getMonthKey } from '@/services/AggregationService'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  activities: Activity[]
+}>()
+
+const granularities: PeriodGranularity[] = ['week', 'month', 'year']
+const granularity = ref<PeriodGranularity>('month')
+
+const distanceCanvas = ref<HTMLCanvasElement | null>(null)
+const countCanvas = ref<HTMLCanvasElement | null>(null)
+let distanceChart: Chart | null = null
+let countChart: Chart | null = null
+
+function getYearKey(date: Date): string {
+  return `${date.getFullYear()}`
+}
+
+function getPeriodKey(date: Date, g: PeriodGranularity): string {
+  if (g === 'week') return getISOWeekKey(date)
+  if (g === 'month') return getMonthKey(date)
+  return getYearKey(date)
+}
+
+function formatPeriodLabel(key: string, g: PeriodGranularity): string {
+  if (g === 'week') {
+    const parts = key.split('-W')
+    return `S${parts[1]}`
+  }
+  if (g === 'month') {
+    const parts = key.split('-')
+    return `${parts[1]}/${parts[0].slice(2)}`
+  }
+  return key
+}
+
+const periodData = computed<PeriodData[]>(() => {
+  const map = new Map<string, PeriodData>()
+
+  for (const a of props.activities) {
+    const date = new Date(toMs(a.startTime))
+    const key = getPeriodKey(date, granularity.value)
+    const existing = map.get(key)
+    if (existing) {
+      existing.distance += (a.distance || 0) / 1000
+      existing.duration += (a.duration || 0) / 3600
+      existing.count += 1
+    } else {
+      map.set(key, {
+        key,
+        label: formatPeriodLabel(key, granularity.value),
+        distance: (a.distance || 0) / 1000,
+        duration: (a.duration || 0) / 3600,
+        count: 1
+      })
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key))
+})
+
+function createOrUpdateCharts() {
+  const labels = periodData.value.map(d => d.label)
+  const distances = periodData.value.map(d => Math.round(d.distance * 10) / 10)
+  const counts = periodData.value.map(d => d.count)
+
+  const style = getComputedStyle(document.documentElement)
+  const green500 = style.getPropertyValue('--color-green-500').trim() || '#88aa00'
+  const green300 = style.getPropertyValue('--color-green-300').trim() || '#cbe56d'
+
+  if (distanceChart) {
+    distanceChart.data.labels = labels
+    distanceChart.data.datasets[0].data = distances
+    distanceChart.update()
+  } else if (distanceCanvas.value) {
+    distanceChart = new Chart(distanceCanvas.value, {
+      type: 'line',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: t('statistics.trends.distance'),
+            data: distances,
+            borderColor: green500,
+            backgroundColor: `${green500}1a`,
+            fill: true,
+            tension: 0.3,
+            pointRadius: 3
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { grid: { display: false } },
+          y: { beginAtZero: true }
+        }
+      }
+    })
+  }
+
+  if (countChart) {
+    countChart.data.labels = labels
+    countChart.data.datasets[0].data = counts
+    countChart.update()
+  } else if (countCanvas.value) {
+    countChart = new Chart(countCanvas.value, {
+      type: 'bar',
+      data: {
+        labels,
+        datasets: [
+          {
+            label: t('statistics.trends.activities'),
+            data: counts,
+            backgroundColor: green300,
+            borderRadius: 4
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { grid: { display: false } },
+          y: { beginAtZero: true, ticks: { stepSize: 1 } }
+        }
+      }
+    })
+  }
+}
+
+function destroyCharts() {
+  distanceChart?.destroy()
+  distanceChart = null
+  countChart?.destroy()
+  countChart = null
+}
+
+watch([periodData, granularity], async () => {
+  await nextTick()
+  if (periodData.value.length > 0) {
+    destroyCharts()
+    createOrUpdateCharts()
+  }
+})
+
+onMounted(async () => {
+  await nextTick()
+  if (periodData.value.length > 0) {
+    createOrUpdateCharts()
+  }
+})
+
+onUnmounted(() => {
+  destroyCharts()
+})
+</script>
+
+<style scoped>
+.section-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 12px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  padding: 1.2rem 1.4rem;
+}
+
+.section-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-title i {
+  color: var(--color-green-500);
+}
+
+.period-toggle {
+  display: flex;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.toggle-btn {
+  padding: 0.3rem 0.8rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-green-200);
+  background: var(--bg-color);
+  color: var(--text-color);
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s;
+  font-family: var(--font-main);
+}
+
+.toggle-btn.active {
+  background: var(--color-green-500);
+  color: #fff;
+  border-color: var(--color-green-500);
+}
+
+.chart-container {
+  width: 100%;
+  height: 220px;
+  margin-bottom: 1rem;
+}
+
+.chart-container:last-child {
+  margin-bottom: 0;
+}
+
+.chart-container canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.empty-chart {
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-color);
+  opacity: 0.6;
+}
+</style>

--- a/plugins/app-extensions/Statistics/composables/usePersonalRecords.ts
+++ b/plugins/app-extensions/Statistics/composables/usePersonalRecords.ts
@@ -1,0 +1,145 @@
+import { ref, watch, type Ref } from 'vue'
+import type { Activity, ActivityDetails } from '@/types/activity'
+import { IndexedDBService } from '@/services/IndexedDBService'
+import { ActivityAnalyzer } from '@/services/ActivityAnalyzer'
+import type { PersonalRecord, PRCache } from '../types'
+
+const PR_TARGETS = [1_000, 2_000, 5_000, 10_000, 15_000, 20_000, 21_097, 42_195]
+
+// Max plausible speed in m/s — 50 km/h filters GPS glitches while keeping any real effort
+const MAX_SPEED_MS = 50 / 3.6
+
+// Bump this to invalidate cached PR data after algorithm changes
+const CACHE_VERSION = 2
+
+const PR_LABELS: Record<number, string> = {
+  1000: '1K',
+  2000: '2K',
+  5000: '5K',
+  10000: '10K',
+  15000: '15K',
+  20000: '20K',
+  21097: 'Semi',
+  42195: 'Marathon'
+}
+
+function cacheKey(sport: string): string {
+  return `statistics_pr_cache_${sport || 'all'}`
+}
+
+export function usePersonalRecords(activities: Ref<Activity[]>, selectedSport: Ref<string>) {
+  const records = ref<PersonalRecord[]>([])
+  const computing = ref(false)
+  const progress = ref(0)
+
+  async function computeRecords() {
+    const acts = activities.value
+    if (acts.length === 0) {
+      records.value = []
+      return
+    }
+
+    const sport = selectedSport.value
+    const activityCount = acts.length
+    const maxLastModified = Math.max(...acts.map(a => a.lastModified || 0))
+
+    // Check cache
+    const db = await IndexedDBService.getInstance()
+    const cached = (await db.getData(cacheKey(sport))) as PRCache | undefined
+    if (
+      cached &&
+      (cached as any).cacheVersion === CACHE_VERSION &&
+      cached.activityCount === activityCount &&
+      cached.maxLastModified === maxLastModified &&
+      cached.sport === sport
+    ) {
+      records.value = cached.records
+      return
+    }
+
+    computing.value = true
+    progress.value = 0
+
+    // Load all activity_details in one batch
+    const allDetails = (await db.getAllData('activity_details')) as ActivityDetails[]
+    const detailsMap = new Map<string, ActivityDetails>()
+    for (const d of allDetails) {
+      detailsMap.set(d.id, d)
+    }
+
+    const best = new Map<number, PersonalRecord>()
+    const chunkSize = 20
+
+    for (let i = 0; i < acts.length; i += chunkSize) {
+      const chunk = acts.slice(i, i + chunkSize)
+
+      for (const activity of chunk) {
+        const details = detailsMap.get(activity.id)
+        if (!details?.samples?.length) continue
+
+        // Skip activities without distance data
+        const hasDistance = details.samples.some(s => s.distance != null && s.time != null)
+        if (!hasDistance) continue
+
+        try {
+          const analyzer = new ActivityAnalyzer(details.samples)
+          const segments = analyzer.bestSegments(PR_TARGETS)
+
+          for (const target of PR_TARGETS) {
+            const seg = segments[target]
+            if (!seg) continue
+
+            // Filter GPS glitches: skip segments with unrealistic speed
+            if (seg.duration <= 0 || target / seg.duration > MAX_SPEED_MS) continue
+
+            const existing = best.get(target)
+            if (!existing || seg.duration < existing.duration) {
+              const paceMinPerKm = seg.duration / (target / 1000) / 60
+              best.set(target, {
+                distance: target,
+                distanceLabel: PR_LABELS[target],
+                duration: seg.duration,
+                pace: paceMinPerKm,
+                speed: target / 1000 / (seg.duration / 3600),
+                date: activity.startTime,
+                activityId: activity.id
+              })
+            }
+          }
+        } catch {
+          // Activity samples may lack required data, skip silently
+        }
+      }
+
+      progress.value = Math.min(100, Math.round(((i + chunk.length) / acts.length) * 100))
+
+      // Yield to main thread
+      if (i + chunkSize < acts.length) {
+        await new Promise(resolve => setTimeout(resolve, 0))
+      }
+    }
+
+    const result = PR_TARGETS.filter(t => best.has(t)).map(t => best.get(t)!)
+    records.value = result
+
+    // Save to cache
+    await db.saveData(cacheKey(sport), {
+      cacheVersion: CACHE_VERSION,
+      activityCount,
+      maxLastModified,
+      sport,
+      records: result
+    })
+
+    computing.value = false
+    progress.value = 100
+  }
+
+  watch([activities, selectedSport], computeRecords, { immediate: true })
+
+  return {
+    records,
+    computing,
+    progress
+  }
+}

--- a/plugins/app-extensions/Statistics/composables/useStatisticsData.ts
+++ b/plugins/app-extensions/Statistics/composables/useStatisticsData.ts
@@ -1,0 +1,84 @@
+import { ref, computed, onUnmounted } from 'vue'
+import type { Activity } from '@/types/activity'
+import { getActivityService } from '@/services/ActivityService'
+import { formatSportType } from '@plugins/app-extensions/Goals/sportLabels'
+
+const allActivities = ref<Activity[]>([])
+const selectedSport = ref<string>('')
+const loading = ref(false)
+let initialized = false
+let activityService: Awaited<ReturnType<typeof getActivityService>> | null = null
+
+const filteredActivities = computed(() => {
+  if (!selectedSport.value) return allActivities.value
+  return allActivities.value.filter(
+    a => a.type?.toLowerCase() === selectedSport.value.toLowerCase()
+  )
+})
+
+const sportTypes = computed(() => {
+  const types = new Set<string>()
+  for (const a of allActivities.value) {
+    if (a.type) types.add(a.type.toLowerCase())
+  }
+  return Array.from(types).sort()
+})
+
+const sportOptions = computed(() => {
+  return sportTypes.value.map(s => ({
+    value: s,
+    label: formatSportType(s)
+  }))
+})
+
+async function loadActivities() {
+  loading.value = true
+  try {
+    if (!activityService) {
+      activityService = await getActivityService()
+    }
+    allActivities.value = await activityService.getAllActivities()
+  } finally {
+    loading.value = false
+  }
+}
+
+function handleActivityChanged() {
+  loadActivities()
+}
+
+async function init() {
+  if (initialized) return
+  initialized = true
+  await loadActivities()
+  if (activityService) {
+    activityService.emitter.addEventListener('activity-changed', handleActivityChanged)
+  }
+  window.addEventListener('openstride:activities-refreshed', handleActivityChanged)
+}
+
+function cleanup() {
+  if (activityService) {
+    activityService.emitter.removeEventListener('activity-changed', handleActivityChanged)
+  }
+  window.removeEventListener('openstride:activities-refreshed', handleActivityChanged)
+  initialized = false
+  activityService = null
+}
+
+export function useStatisticsData() {
+  init()
+
+  onUnmounted(() => {
+    cleanup()
+  })
+
+  return {
+    allActivities,
+    filteredActivities,
+    selectedSport,
+    sportTypes,
+    sportOptions,
+    loading
+  }
+}

--- a/plugins/app-extensions/Statistics/index.ts
+++ b/plugins/app-extensions/Statistics/index.ts
@@ -1,0 +1,22 @@
+import type { ExtensionPlugin } from '@/types/extension'
+
+const NavLink = () => import('./components/StatisticsNavLink.vue')
+
+const plugin: ExtensionPlugin = {
+  id: 'statistics',
+  label: 'Statistics',
+  description: 'Global statistics with trends, distribution, personal records and calendar heatmap',
+  icon: 'fas fa-chart-bar',
+  slots: {
+    'navigation.main': [NavLink]
+  },
+  routes: [
+    {
+      path: '/statistics',
+      name: 'Statistics',
+      component: () => import('./components/StatisticsView.vue')
+    }
+  ]
+}
+
+export default plugin

--- a/plugins/app-extensions/Statistics/types.ts
+++ b/plugins/app-extensions/Statistics/types.ts
@@ -1,0 +1,33 @@
+export interface PersonalRecord {
+  distance: number
+  distanceLabel: string
+  duration: number
+  pace: number
+  speed: number
+  date: number
+  activityId: string
+}
+
+export interface PRCache {
+  activityCount: number
+  maxLastModified: number
+  sport: string
+  records: PersonalRecord[]
+}
+
+export type PeriodGranularity = 'week' | 'month' | 'year'
+
+export type HeatmapMetric = 'distance' | 'duration' | 'count'
+
+/** Convert startTime to milliseconds (handles both seconds and ms formats) */
+export function toMs(timestamp: number): number {
+  return timestamp < 1e11 ? timestamp * 1000 : timestamp
+}
+
+export interface PeriodData {
+  key: string
+  label: string
+  distance: number
+  duration: number
+  count: number
+}

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -44,6 +44,12 @@
       <router-link to="/my-activities" @click="closeMenu">{{
         t('navigation.myActivities')
       }}</router-link>
+      <component
+        v-for="(comp, i) in navSlotComponents"
+        :is="comp"
+        :key="`nav-${i}`"
+        @navigate="closeMenu"
+      />
       <router-link to="/friends" @click="closeMenu">{{ t('navigation.friends') }}</router-link>
       <router-link to="/profile" @click="closeMenu">{{ t('navigation.profile') }}</router-link>
       <button class="refresh-btn" @click="onRefresh" :disabled="refreshing">
@@ -69,15 +75,19 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { DataProviderService } from '@/services/DataProviderService'
 import { getSyncService } from '@/services/SyncService'
 import { StorageService } from '@/services/StorageService'
 import { FriendService } from '@/services/FriendService'
 import { ToastService } from '@/services/ToastService'
+import { useSlotExtensions } from '@/composables/useSlotExtensions'
 
 const { t } = useI18n()
+
+const { components: navRaw } = useSlotExtensions('navigation.main')
+const navSlotComponents = computed(() => navRaw.value.map(c => c.default || c))
 
 const isMenuOpen = ref(false)
 const refreshing = ref(false)

--- a/src/composables/useSlotExtensions.ts
+++ b/src/composables/useSlotExtensions.ts
@@ -7,7 +7,11 @@ export function useSlotExtensions(slotName: string) {
   const components = shallowRef<Component[]>([])
 
   onMounted(async () => {
-    components.value = await getPluginViewsForSlot(slotName)
+    try {
+      components.value = await getPluginViewsForSlot(slotName)
+    } catch {
+      // IndexedDB may not be available (e.g. in test environment)
+    }
   })
 
   return { components }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,7 +25,8 @@
     "dataProviders": "Data Providers",
     "storageProviders": "Storage Providers",
     "appExtensions": "App Extensions",
-    "myActivities": "My Activities"
+    "myActivities": "My Activities",
+    "statistics": "Statistics"
   },
   "profile": {
     "createProfile": "Create a Profile",
@@ -203,6 +204,48 @@
     "pleaseWait": "Please wait, this may take a few moments",
     "success": "Update completed successfully",
     "failed": "Update failed. Please try again."
+  },
+  "statistics": {
+    "title": "Statistics",
+    "allSports": "All sports",
+    "noData": "No data available",
+    "noDataHint": "Import activities to see your statistics",
+    "trends": {
+      "title": "Trends",
+      "distance": "Distance (km)",
+      "activities": "Activities",
+      "week": "Week",
+      "month": "Month",
+      "year": "Year"
+    },
+    "distribution": {
+      "title": "Distribution",
+      "bySport": "By sport",
+      "byMonth": "By month",
+      "activitiesCount": "Activity count",
+      "distanceKm": "Distance (km)",
+      "durationH": "Duration (h)"
+    },
+    "records": {
+      "title": "Personal Records",
+      "distance": "Distance",
+      "time": "Time",
+      "pace": "Pace",
+      "speed": "Speed",
+      "date": "Date",
+      "activity": "Activity",
+      "computing": "Computing records...",
+      "noRecords": "No records found",
+      "noRecordsHint": "Records are computed from GPS data in your activities"
+    },
+    "heatmap": {
+      "title": "Activity Calendar",
+      "less": "Less",
+      "more": "More",
+      "distance": "Distance",
+      "duration": "Duration",
+      "count": "Activities"
+    }
   },
   "goals": {
     "title": "Goals",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -25,7 +25,8 @@
     "dataProviders": "Sources de données",
     "storageProviders": "Stockage cloud",
     "appExtensions": "Extensions",
-    "myActivities": "Mes activités"
+    "myActivities": "Mes activités",
+    "statistics": "Statistiques"
   },
   "profile": {
     "createProfile": "Créer un Profil",
@@ -203,6 +204,48 @@
     "pleaseWait": "Veuillez patienter, cela peut prendre quelques instants",
     "success": "Mise à jour réussie",
     "failed": "Échec de la mise à jour. Veuillez réessayer."
+  },
+  "statistics": {
+    "title": "Statistiques",
+    "allSports": "Tous les sports",
+    "noData": "Aucune donnee disponible",
+    "noDataHint": "Importez des activites pour voir vos statistiques",
+    "trends": {
+      "title": "Tendances",
+      "distance": "Distance (km)",
+      "activities": "Activites",
+      "week": "Semaine",
+      "month": "Mois",
+      "year": "Annee"
+    },
+    "distribution": {
+      "title": "Repartition",
+      "bySport": "Par sport",
+      "byMonth": "Par mois",
+      "activitiesCount": "Nombre d'activites",
+      "distanceKm": "Distance (km)",
+      "durationH": "Duree (h)"
+    },
+    "records": {
+      "title": "Records personnels",
+      "distance": "Distance",
+      "time": "Temps",
+      "pace": "Allure",
+      "speed": "Vitesse",
+      "date": "Date",
+      "activity": "Activite",
+      "computing": "Calcul des records en cours...",
+      "noRecords": "Aucun record trouve",
+      "noRecordsHint": "Les records sont calcules a partir des donnees GPS de vos activites"
+    },
+    "heatmap": {
+      "title": "Calendrier d'activite",
+      "less": "Moins",
+      "more": "Plus",
+      "distance": "Distance",
+      "duration": "Duree",
+      "count": "Activites"
+    }
   },
   "goals": {
     "title": "Objectifs",

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,17 @@ async function bootstrap() {
   const pwaUpdateService = getPWAUpdateService()
   await pwaUpdateService.initialize()
 
-  // 5. Create and mount Vue app
+  // 5. Register plugin routes
+  const { allAppPlugins } = await import('@/services/ExtensionPluginRegistry')
+  for (const plugin of allAppPlugins) {
+    if (plugin.routes) {
+      for (const route of plugin.routes) {
+        router.addRoute(route)
+      }
+    }
+  }
+
+  // 6. Create and mount Vue app
   const app = createApp(App)
   app.use(router)
   app.use(i18n)

--- a/src/services/AppExtensionPluginManager.ts
+++ b/src/services/AppExtensionPluginManager.ts
@@ -16,7 +16,8 @@ export class AppExtensionPluginManager extends PluginManagerBase<ExtensionPlugin
     'standard-details',
     'aggregated-details',
     'profile-sharing',
-    'goals'
+    'goals',
+    'statistics'
   ]
 
   private constructor() {

--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -12,4 +12,11 @@ export interface ExtensionPlugin {
   slots?: {
     [slotName: string]: Array<() => Promise<Component>>
   }
+
+  // Routes à injecter dynamiquement dans le routeur
+  routes?: Array<{
+    path: string
+    name?: string
+    component: () => Promise<Component>
+  }>
 }


### PR DESCRIPTION
## Summary

- Add a **Statistics** app-extension plugin with 4 sections: **Trends** (Chart.js line/bar by week/month/year), **Distribution** (doughnut + horizontal bars by sport), **Personal Records** (best segments 1K–marathon with GPS glitch filtering + IndexedDB cache), and **Calendar Heatmap** (CSS grid with auto-scroll)
- Global **sport filter** shared across all sections
- Slot-based **navigation injection** (`navigation.main` slot) — no hardcoded plugin references in core files
- Auto-enable for existing users via `PluginManagerBase` known-defaults tracking
- Full **fr/en i18n** support

## Test plan

- [ ] Navigate to `/statistics` — verify all 4 sections render with data
- [ ] Select a sport filter — all sections update accordingly
- [ ] Check Personal Records computation (progress bar, then table with sane values)
- [ ] Verify Calendar Heatmap scrolls to recent dates on mobile, no visible scrollbar
- [ ] Disable the plugin in Profile > App Extensions — nav link disappears, page still accessible via direct URL
- [ ] Re-enable the plugin — nav link reappears
- [ ] `npm run build` passes
- [ ] `npm run test:unit` passes (219 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)