### PR TITLE
fix(functions): make Strava relay credentials optional at deploy

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,23 +20,25 @@ const GARMIN_WEBHOOK_SECRET = defineSecret('GARMIN_WEBHOOK_SECRET')
 
 // Pull providers (OAuth2 + REST pull). The client drives everything; the relay
 // only injects the client secret at token exchange and adds CORS to API GETs —
-// no data is buffered or stored. Add a provider by extending PROVIDERS below.
-const STRAVA_CLIENT_ID = defineSecret('STRAVA_CLIENT_ID')
-const STRAVA_CLIENT_SECRET = defineSecret('STRAVA_CLIENT_SECRET')
-
+// no data is buffered or stored. Add a provider by extending PULL_PROVIDERS below.
+//
+// Credentials are read lazily from process.env (optional) rather than bound
+// Firebase secrets, so a provider stays dormant — and the deploy succeeds —
+// until its env vars are provisioned. A missing credential yields a 503 at
+// token exchange instead of blocking deployment.
 interface ProviderConfig {
   tokenUrl: string
   apiBase: string
-  clientId: ReturnType<typeof defineSecret>
-  clientSecret: ReturnType<typeof defineSecret>
+  clientId: () => string | undefined
+  clientSecret: () => string | undefined
 }
 
 const PULL_PROVIDERS: Record<string, ProviderConfig> = {
   strava: {
     tokenUrl: 'https://www.strava.com/oauth/token',
     apiBase: 'https://www.strava.com/api/v3',
-    clientId: STRAVA_CLIENT_ID,
-    clientSecret: STRAVA_CLIENT_SECRET
+    clientId: () => process.env.STRAVA_CLIENT_ID,
+    clientSecret: () => process.env.STRAVA_CLIENT_SECRET
   }
 }
 
@@ -123,13 +125,7 @@ async function resolveUserId(authHeader?: string): Promise<string | null> {
 export const garminProxy = onRequest(
   {
     cors: true,
-    secrets: [
-      GARMIN_CLIENT_ID,
-      GARMIN_CLIENT_SECRET,
-      GARMIN_WEBHOOK_SECRET,
-      STRAVA_CLIENT_ID,
-      STRAVA_CLIENT_SECRET
-    ],
+    secrets: [GARMIN_CLIENT_ID, GARMIN_CLIENT_SECRET, GARMIN_WEBHOOK_SECRET],
     region: 'europe-west1',
     memory: '1GiB'
   },
@@ -314,11 +310,22 @@ export const garminProxy = onRequest(
       // POST /{provider}/token — inject client id/secret, forward to the provider.
       if (seg[1] === 'token' && req.method === 'POST') {
         try {
+          const clientId = cfg.clientId()
+          const clientSecret = cfg.clientSecret()
+          // Provider not provisioned yet (no env vars) → stay dormant.
+          if (!clientId || !clientSecret) {
+            res
+              .set(cors)
+              .status(503)
+              .json({ error: `Provider "${seg[0]}" is not configured` })
+            return
+          }
+
           const body =
             typeof req.body === 'string' ? req.body : new URLSearchParams(req.body).toString()
           const params = new URLSearchParams(body)
-          params.set('client_id', cfg.clientId.value())
-          params.set('client_secret', cfg.clientSecret.value())
+          params.set('client_id', clientId)
+          params.set('client_secret', clientSecret)
 
           const response = await fetch(cfg.tokenUrl, {
             method: 'POST',


### PR DESCRIPTION
Unblocks the production deploy that failed after merging #68.

## Problem
The Strava scaffold declared `STRAVA_CLIENT_ID` / `STRAVA_CLIENT_SECRET` as **bound Firebase secrets**. On `firebase deploy` in non-interactive CI mode this fails hard:
`Error: In non-interactive mode but have no value for the secret: STRAVA_CLIENT_ID`
The version bump to **0.5.0** landed, but prod was never deployed.

## Fix
Read Strava credentials lazily from `process.env` (optional) instead of bound secrets, and return `503 "Provider not configured"` at token exchange when absent. Garmin secrets are untouched. Strava stays dormant until `STRAVA_CLIENT_ID` / `STRAVA_CLIENT_SECRET` env vars are provisioned.

## Result
- Prod deploy succeeds; sync fixes + Garmin ship live.
- To activate Strava later: set the two env vars (or reintroduce them as bound secrets + provision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)