### PR TITLE
feat(scan): remonter les scalaires des détails dans l'index d'activité

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,9 +142,17 @@ Most stores are replicated to the user's storage provider. A store listed in
 `LOCAL_ONLY_STORES` (`src/services/StorageService.ts`) never leaves the device:
 it holds values derived from data that is already synced, so uploading it would
 cost bandwidth for something we can recompute, and losing it only costs a
-rebuild. `activity_metrics` — the per-activity best times behind the records
-and the metric tracker — is the current example. Add derived caches there
+rebuild. `activity_metrics` is the current example. Add derived caches there
 rather than to `settings`, which _is_ replicated.
+
+`activity_metrics` holds one row per activity, lifted from its details at scan
+time by `useActivityMetricsIndex`: the best times behind the records and the
+metric tracker, plus the `DERIVED` scalars (calories, ascent, descent, max
+speed, heart rates) a feed card needs but cannot reach — a card only ever
+receives an `Activity`. Adding a value means extending `computeValues()` **and**
+bumping `INDEX_VERSION`, which recomputes every row. Values stay SI: a cache
+that stored converted numbers would depend on a display preference. See
+`docs/SPORT_AND_UNITS.md` §10 bis.
 
 ## Related Documentation
 

--- a/docs/SPORT_AND_UNITS.md
+++ b/docs/SPORT_AND_UNITS.md
@@ -8,16 +8,17 @@ donnée, parce qu'une règle dont on a oublié le motif finit par être contourn
 
 ## En un coup d'œil
 
-| J'ai besoin de…                                    | J'utilise                                        |
-| -------------------------------------------------- | ------------------------------------------------ |
-| Afficher une valeur chiffrée                       | `format(dimension, si)`                          |
-| Alimenter un axe ou une série de graphe            | `convert(dimension, si).value`                   |
-| Savoir quelle métrique mettre en avant             | `primaryMetricSpec(sport, …)`                    |
-| Afficher une distance totale                       | `distanceDimension(sport)` puis `format`         |
-| Ajouter un sport                                   | `SPORT_TYPES` + `SPORT_FAMILY`                   |
-| Ajouter une donnée propre à un sport               | `MEASUREMENT_KEYS` + `MEASUREMENTS`              |
-| Ajouter un widget de détail                        | un `SlotEntry` avec `appliesTo`                  |
-| Accéder à un service core depuis un plugin         | `PluginContext`                                  |
+| J'ai besoin de…                              | J'utilise                                |
+| -------------------------------------------- | ---------------------------------------- |
+| Afficher une valeur chiffrée                 | `format(dimension, si)`                  |
+| Alimenter un axe ou une série de graphe      | `convert(dimension, si).value`           |
+| Savoir quelle métrique mettre en avant       | `primaryMetricSpec(sport, …)`            |
+| Afficher une distance totale                 | `distanceDimension(sport)` puis `format` |
+| Ajouter un sport                             | `SPORT_TYPES` + `SPORT_FAMILY`           |
+| Ajouter une donnée propre à un sport         | `MEASUREMENT_KEYS` + `MEASUREMENTS`      |
+| Ajouter un widget de détail                  | un `SlotEntry` avec `appliesTo`          |
+| Accéder à un service core depuis un plugin   | `PluginContext`                          |
+| Afficher sur une card une valeur des détails | `computeValues()` + `DERIVED`            |
 
 ---
 
@@ -179,7 +180,7 @@ ce qu'était `62`. Une mesure porte toujours son unité.
 sur une nage en bassin parce qu'il n'y a pas d'altitude — pas parce que c'est de
 la natation. Le sport n'intervient que quand la même donnée change de sens.
 
-La sélection renvoie des *loaders* et filtre **avant** l'import : un widget écarté
+La sélection renvoie des _loaders_ et filtre **avant** l'import : un widget écarté
 ne coûte pas son chunk. Ne jamais filtrer après chargement.
 
 Un loader nu (sans `id`) reste accepté et signifie « s'applique toujours ».
@@ -214,6 +215,44 @@ vivaient dans le bloc carte et ont dû être relogés.
 
 La conversion a lieu **au dernier moment, à la frontière du rendu**.
 
+## 10 bis. Afficher sur une card une valeur qui vit dans les détails
+
+**Ajouter la valeur à `computeValues()` dans `useActivityMetricsIndex`, bumper
+`INDEX_VERSION`, lire `derived.value.get(id)` côté composant.**
+
+Une card de feed ne reçoit qu'un `Activity` : ni `stats`, ni `samples`, ni
+`measurements`. Charger les détails par card est exclu — ce sont les samples, la
+partie lourde du stockage, pour afficher un nombre.
+
+Le store `activity_metrics` existe pour ça. Il tient une ligne par activité :
+
+```ts
+{ id, startTime, sport, indexVersion, values: Record<string, number> }
+```
+
+`values` est volontairement ouvert. `DERIVED` en nomme les clés connues
+(`calories`, `ascent`, `descent`, `maxSpeed`, `avgHeartRate`, `maxHeartRate`),
+`timeMetricId(m)` celles des meilleurs temps.
+
+Le scan est **incrémental et paresseux** : `useFeedMetricsIndex(activities)` dans
+une vue de feed n'indexe que la page affichée, et une ligne déjà à jour n'est
+jamais recalculée. Une card sans ligne n'affiche simplement rien — elle ne
+patiente pas, elle se remplit quand la valeur arrive.
+
+Trois contraintes, chacune payée une fois :
+
+- **SI uniquement** (§10) — c'est un cache, une conversion qui y fuit le lie à
+  une préférence d'affichage.
+- **Bumper `INDEX_VERSION`** dès qu'on ajoute une valeur ou change un calcul,
+  sinon les lignes existantes restent muettes pour la nouvelle clé.
+- **Rien de sensible** : le store est dans `LOCAL_ONLY_STORES`, il ne quitte
+  jamais l'appareil. Le perdre coûte un recalcul, jamais une donnée.
+
+> **Zéro calculé ≠ zéro déclaré.** Un `totalDescent` à 0 renvoyé par le provider
+> dit « c'était plat ». Un dénivelé recalculé à 0 dit seulement « la trace n'a
+> jamais dépassé le seuil de bruit » : on ne le stocke pas, sinon la card
+> afficherait « 0 m » là où il n'y a rien à dire (§9).
+
 ## 11. Longueur de bassin
 
 Dimension `poolLength`, jamais `distanceShort`.
@@ -240,13 +279,13 @@ Pour les unités : `ctx.units.format()` / `ctx.units.convert()` / `ctx.units.sys
 Le contrat que le provider doit à core, vérifié à l'écriture par
 `checkActivityContract` (`src/services/activityContract.ts`) :
 
-| Champ | Attendu |
-| ----- | ------- |
-| `type` | un slug canonique — mapper dans le `sportTypes.ts` du provider |
-| `distance` | mètres |
-| `duration` | secondes |
-| `stats.averageSpeed` | m/s |
-| `measurements` | clés du registre, avec l'unité que le registre déclare |
+| Champ                | Attendu                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `type`               | un slug canonique — mapper dans le `sportTypes.ts` du provider |
+| `distance`           | mètres                                                         |
+| `duration`           | secondes                                                       |
+| `stats.averageSpeed` | m/s                                                            |
+| `measurements`       | clés du registre, avec l'unité que le registre déclare         |
 
 `saveActivityWithDetails()` appelle la vérification et **avertit en console en
 développement** — sans jamais refuser l'écriture : une base réelle contient des
@@ -269,15 +308,15 @@ Partir de `tests/fixtures/activities.ts`, pas d'un objet écrit à la main :
 import { createActivity, createSwimActivity, createSwimDetails } from '../fixtures/activities'
 ```
 
-| Fixture                        | Ce qu'elle représente                                |
-| ------------------------------ | ---------------------------------------------------- |
-| `createActivity()`             | Course avec tracé — allure /km, échelle longue       |
-| `createRideActivity()`         | Vélo — vitesse                                        |
-| `createSwimActivity()`         | Bassin — sans GPS, échelle courte, allure /100       |
-| `createSwimDetails()`          | Les mesures natation telles qu'un provider les fournit |
-| `createGymActivity()`          | Salle — sans distance ni allure                       |
-| `createLegacyActivity()`       | Type brut `"RUNNING"`, antérieur au vocabulaire       |
-| `createActivitiesAcrossSports()` | Une de chaque, pour balayer les formes              |
+| Fixture                          | Ce qu'elle représente                                  |
+| -------------------------------- | ------------------------------------------------------ |
+| `createActivity()`               | Course avec tracé — allure /km, échelle longue         |
+| `createRideActivity()`           | Vélo — vitesse                                         |
+| `createSwimActivity()`           | Bassin — sans GPS, échelle courte, allure /100         |
+| `createSwimDetails()`            | Les mesures natation telles qu'un provider les fournit |
+| `createGymActivity()`            | Salle — sans distance ni allure                        |
+| `createLegacyActivity()`         | Type brut `"RUNNING"`, antérieur au vocabulaire        |
+| `createActivitiesAcrossSports()` | Une de chaque, pour balayer les formes                 |
 
 Un test unitaire qui bascule les unités doit **remettre la préférence** à la fin
 (`setUnitSystem('metric')`) : c'est un singleton de module.
@@ -303,13 +342,14 @@ Un test unitaire qui bascule les unités doit **remettre la préférence** à la
 
 ## Symptôme → cause → règle
 
-| Symptôme                                        | Cause                                     | Règle |
-| ----------------------------------------------- | ----------------------------------------- | ----- |
-| Des km apparaissent en mode impérial            | Conversion écrite à la main               | §1    |
-| Un graphe reste en métrique après changement    | Canvas non redessiné                      | §2    |
-| Une allure disparaît sur d'anciennes activités  | Recherche sensible à la casse             | §6    |
-| `62` sans savoir si ce sont des pas ou des coups | Mesure stockée sans unité                 | §7    |
-| Un widget vide sur un sport                     | `appliesTo` absent ou basé sur le sport   | §8    |
-| Un grand bloc gris sans information             | Substitut affiché au lieu de rien         | §9    |
-| Un record change avec la préférence             | Valeur convertie stockée                  | §10   |
-| Un bassin de « 27 yd »                          | `distanceShort` au lieu de `poolLength`   | §11   |
+| Symptôme                                         | Cause                                              | Règle   |
+| ------------------------------------------------ | -------------------------------------------------- | ------- |
+| Des km apparaissent en mode impérial             | Conversion écrite à la main                        | §1      |
+| Un graphe reste en métrique après changement     | Canvas non redessiné                               | §2      |
+| Une allure disparaît sur d'anciennes activités   | Recherche sensible à la casse                      | §6      |
+| `62` sans savoir si ce sont des pas ou des coups | Mesure stockée sans unité                          | §7      |
+| Un widget vide sur un sport                      | `appliesTo` absent ou basé sur le sport            | §8      |
+| Un grand bloc gris sans information              | Substitut affiché au lieu de rien                  | §9      |
+| Un record change avec la préférence              | Valeur convertie stockée                           | §10     |
+| Un bassin de « 27 yd »                           | `distanceShort` au lieu de `poolLength`            | §11     |
+| Une valeur des détails absente de la card        | Pas remontée au scan, ou `INDEX_VERSION` non bumpé | §10 bis |

--- a/plugins/app-extensions/StandardDetails/ActivityTopBlock.vue
+++ b/plugins/app-extensions/StandardDetails/ActivityTopBlock.vue
@@ -78,7 +78,23 @@ const iconClass = computed(() => getSportIcon(activity.value.type))
 // ── Formatters ──────────────────────────────────────────────
 const pad = (n: number) => String(n).padStart(2, '0')
 
-const { units } = usePluginContext()
+const { units, analyzer: analyzerFactory } = usePluginContext()
+
+/**
+ * Metres descended.
+ *
+ * Providers that report it win; for everyone else — every activity stored
+ * before this existed, and Strava — it is recomputed from the elevation
+ * samples, noise-filtered.
+ */
+const totalDescent = computed<number | undefined>(() => {
+  const reported = details.value?.stats?.totalDescent
+  if (reported != null) return reported
+  const samples = details.value?.samples
+  if (!samples?.length) return undefined
+  const { descent } = analyzerFactory.create(samples).elevationChange()
+  return descent > 0 ? descent : undefined
+})
 
 const formatDistance = (meters?: number) =>
   units.format(distanceDimension(activity.value.type), meters ?? 0)
@@ -182,6 +198,17 @@ const primaryStats = computed<Stat[]>(() => {
       unit: ascent.unit
     })
   }
+
+  // The twin of the ascent, and the number a skier actually reads — a day on
+  // the slopes climbs almost nothing and descends thousands of metres.
+  if (totalDescent.value != null) {
+    const descent = units.format('elevation', totalDescent.value)
+    out.push({
+      label: t('activityDetail.elevationDown', 'Elevation -'),
+      value: descent.value,
+      unit: descent.unit
+    })
+  }
   return out
 })
 
@@ -213,6 +240,11 @@ const secondaryStats = computed<Stat[]>(() => {
       value: Math.round(s.maxHeartRate).toString(),
       unit: 'bpm'
     })
+  // Stored by every provider, displayed nowhere until now.
+  if (s?.maxSpeed != null) {
+    const max = units.format('speed', s.maxSpeed)
+    out.push({ label: t('activityDetail.maxSpeed', 'Max speed'), value: max.value, unit: max.unit })
+  }
   return out
 })
 </script>

--- a/plugins/app-extensions/StandardDetails/SpeedSampled.vue
+++ b/plugins/app-extensions/StandardDetails/SpeedSampled.vue
@@ -38,7 +38,7 @@
     <div class="mt-6">
       <div class="flex text-xs sm:text-sm font-semibold border-b pb-1 mb-1">
         <span class="w-16">{{ t('graphs.colDistance') }}</span>
-        <span class="flex-1">{{ t('graphs.colPace') }}</span>
+        <span class="flex-1">{{ graphTitle }}</span>
         <span class="w-10 text-right">{{ paceUnit }}</span>
         <span class="w-12 text-right">{{ t('graphs.colHeartRate') }}</span>
         <span class="w-20 text-right">{{ t('graphs.colSlope') }}</span>
@@ -466,12 +466,16 @@ function showTooltip(event: MouseEvent | TouchEvent) {
 function paceSec(sample: Sample) {
   return (sample.speed ?? 0) > 0 ? 1000 / (sample.speed as number) : Infinity
 }
+/**
+ * The row's headline figure, in whatever this chart plots.
+ *
+ * It has to agree with the column header, which carries `paceUnit`: a ski
+ * listing "1:38" under a "km/h" heading is worse than either alone.
+ */
 function paceStr(sample: Sample) {
-  const p = paceSec(sample)
-  if (!isFinite(p)) return '—'
-  const m = Math.floor(p / 60)
-  const s = String(Math.round(p % 60)).padStart(2, '0')
-  return `${m}:${s}`
+  const speed = sample.speed ?? 0
+  if (!isFinite(speed) || speed <= 0) return '—'
+  return axisLabel(toAxis(speed))
 }
 /* largeur relative : plus la pace est rapide, plus la barre est longue  */
 function paceBarWidth(sample: Sample) {

--- a/plugins/data-providers/GarminProvider/client/adapter.ts
+++ b/plugins/data-providers/GarminProvider/client/adapter.ts
@@ -101,6 +101,7 @@ export function adaptGarminDetails(garmin: GarminRawActivity): ActivityDetails {
         summary.averageBikingCadenceInRevPerMinute ??
         summary.averageSwimCadenceInStrokesPerMinute) as number | undefined,
       totalAscent: summary.totalElevationGainInMeters as number | undefined,
+      totalDescent: summary.totalElevationLossInMeters as number | undefined,
       calories: summary.activeKilocalories as number | undefined
     },
     version: 1,

--- a/src/components/ActivityCard.vue
+++ b/src/components/ActivityCard.vue
@@ -53,13 +53,18 @@
             <span class="acard__label">{{ t('activityCard.time', 'Time') }}</span>
             <span class="acard__value">{{ formatDuration(activity.duration) }}</span>
           </div>
-          <!-- Gym sports have no meaningful pace or speed: show time and distance only -->
+          <!-- Gym sports have no meaningful pace or speed: the energy spent takes
+               the accent slot instead, once the scan has lifted it out of the details -->
           <div v-if="primaryMetric.label" class="acard__metric acard__metric--accent">
             <span class="acard__label">{{ primaryMetric.label }}</span>
             <span class="acard__value">
               {{ primaryMetric.value
               }}<small v-if="primaryMetric.unit">{{ primaryMetric.unit }}</small>
             </span>
+          </div>
+          <div v-else-if="calories" class="acard__metric acard__metric--accent">
+            <span class="acard__label">{{ t('activityCard.calories', 'Calories') }}</span>
+            <span class="acard__value">{{ calories }}<small>kcal</small></span>
           </div>
         </div>
       </div>
@@ -90,6 +95,7 @@ import type { Friend, FriendActivity } from '@/types/friend'
 import { formatSportType, getSportIcon } from '@/utils/sportLabels'
 import { distanceDimension, primaryMetricSpec } from '@/utils/activityMetrics'
 import { useUnits } from '@/composables/useUnits'
+import { DERIVED, useActivityMetricsIndex } from '@/composables/useActivityMetricsIndex'
 
 const props = defineProps<{
   activity: Activity
@@ -124,18 +130,38 @@ const distance = computed(() =>
 )
 
 /**
+ * Values the scan lifted out of this activity's details (see
+ * `useActivityMetricsIndex`). Absent until the feed has indexed the page — the
+ * card renders without them rather than waiting, and fills in when they land.
+ */
+const { derived } = useActivityMetricsIndex()
+const scanned = computed(() => derived.value.get(props.activity.id))
+
+const calories = computed(() => {
+  const kcal = scanned.value?.[DERIVED.calories]
+  return kcal ? Math.round(kcal) : 0
+})
+
+/**
  * The accent metric. The sport decides *which* quantity, the user's preference
  * decides the unit; `primaryMetricSpec` owns the first half for every caller.
  */
 const primaryMetric = computed<{ label: string; value: string; unit: string }>(() => {
   const spec = primaryMetricSpec(props.activity.type, {
     distance: props.activity.distance,
-    duration: props.activity.duration
+    duration: props.activity.duration,
+    // Only reachable through the scan: a hike headlines its climb here just as
+    // it does on the detail page, instead of falling back to a pace.
+    ascent: scanned.value?.[DERIVED.ascent]
   })
   if (!spec) return { label: '', value: '', unit: '' }
 
   const label =
-    spec.dimension === 'speed' ? t('activityCard.speed', 'Speed') : t('activityCard.pace', 'Pace')
+    spec.dimension === 'speed'
+      ? t('activityCard.speed', 'Speed')
+      : spec.dimension === 'elevation'
+        ? t('activityCard.elevation', 'Elevation +')
+        : t('activityCard.pace', 'Pace')
   return { label, ...format(spec.dimension, spec.si) }
 })
 

--- a/src/composables/useActivityMetricsIndex.ts
+++ b/src/composables/useActivityMetricsIndex.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, watch, type Ref } from 'vue'
 import type { Activity, ActivityDetails } from '@/types/activity'
 import { getPluginContext } from '@/services/PluginContextFactory'
 import type { PluginContext } from '@/types/plugin-context'
@@ -31,6 +31,30 @@ export function timeMetricId(meters: number): string {
   return `time_${meters}`
 }
 
+/**
+ * Scalars lifted out of the details at scan time.
+ *
+ * A feed card only ever holds an `Activity`; everything else a card could show —
+ * the calories of a gym session, the climb of a hike — lives in
+ * `ActivityDetails`, whose samples are far too heavy to load per card. Lifting
+ * the handful of numbers here is what this store is for: they are recomputable,
+ * so they live in a device-local cache and never sync.
+ *
+ * SI throughout, like everything stored: metres, metres per second, bpm.
+ * Converting here would make a cache depend on a display preference.
+ */
+export const DERIVED = {
+  calories: 'calories',
+  /** Metres climbed — reported by the provider, or recovered from the samples. */
+  ascent: 'ascent',
+  /** Metres descended — the figure a skier reads. */
+  descent: 'descent',
+  /** Metres per second. */
+  maxSpeed: 'maxSpeed',
+  avgHeartRate: 'avgHeartRate',
+  maxHeartRate: 'maxHeartRate'
+} as const
+
 /** Per-activity derived values, keyed by activity id */
 export type DerivedMap = Map<string, Record<string, number>>
 
@@ -45,8 +69,8 @@ export interface ActivityMetricsRow {
   values: Record<string, number>
 }
 
-/** Bump to recompute every row after an algorithm change */
-const INDEX_VERSION = 1
+/** Bump to recompute every row after an algorithm change, or a new derived value */
+export const INDEX_VERSION = 2
 
 // Max plausible speed in m/s — 50 km/h filters GPS glitches while keeping any real effort
 const MAX_SPEED_MS = 50 / 3.6
@@ -63,7 +87,10 @@ const derived = ref<DerivedMap>(new Map())
 const indexing = ref(false)
 const progress = ref(0)
 
-let indexRequest: Promise<void> | null = null
+let indexRequest: Promise<void> = Promise.resolve()
+
+/** A failed pass must not poison the queue, nor surface as an unhandled rejection */
+const swallow = () => undefined
 
 async function loadDetails(
   ctx: PluginContext,
@@ -90,10 +117,50 @@ async function loadDetails(
   return detailsMap
 }
 
-/** Best time on each target distance, in seconds */
+/**
+ * Everything worth keeping from one activity's details: the best time on each
+ * target distance (in seconds), plus the `DERIVED` scalars.
+ *
+ * This is the only place details are read for the index, so it is the only place
+ * to add a value to. Anything missing is simply absent from the record — a
+ * caller reads `undefined` and drops its slot, which is the app's rule for
+ * missing data everywhere else.
+ */
 function computeValues(ctx: PluginContext, details: ActivityDetails): Record<string, number> {
   const values: Record<string, number> = {}
+  const set = (key: string, value: number | undefined | null) => {
+    if (typeof value === 'number' && Number.isFinite(value)) values[key] = value
+  }
+
+  const stats = details.stats
+  set(DERIVED.calories, stats?.calories)
+  set(DERIVED.maxSpeed, stats?.maxSpeed)
+  set(DERIVED.avgHeartRate, stats?.averageHeartRate)
+  set(DERIVED.maxHeartRate, stats?.maxHeartRate)
+  set(DERIVED.ascent, stats?.totalAscent)
+  set(DERIVED.descent, stats?.totalDescent)
+
   if (!details.samples?.length) return values
+
+  // Providers that report the elevation win; for everyone else — Strava, and
+  // every activity stored before totalDescent existed — recover it from the
+  // barometric trace rather than leave the card blank.
+  const missingElevation =
+    values[DERIVED.ascent] === undefined || values[DERIVED.descent] === undefined
+  if (missingElevation && details.samples.some(s => s.elevation != null)) {
+    try {
+      const change = ctx.analyzer.create(details.samples).elevationChange()
+      // A *reported* zero is the provider stating the ground was flat; a
+      // *computed* zero only says the trace never moved past the noise floor,
+      // which is "nothing to show", as the detail page already treats it.
+      if (values[DERIVED.ascent] === undefined && change.ascent > 0)
+        set(DERIVED.ascent, change.ascent)
+      if (values[DERIVED.descent] === undefined && change.descent > 0)
+        set(DERIVED.descent, change.descent)
+    } catch {
+      // Samples may lack what the analyzer needs; the other values still stand
+    }
+  }
 
   // An activity with no distance channel can't yield a segment
   if (!details.samples.some(s => s.distance != null && s.time != null)) return values
@@ -184,13 +251,18 @@ async function buildIndex(activities: Activity[]): Promise<void> {
 }
 
 export function useActivityMetricsIndex() {
-  /** Coalesces concurrent calls so a rebuild never runs twice */
+  /**
+   * Queue a pass, never two at once.
+   *
+   * Serialised rather than coalesced: callers pass different lists — the feed
+   * the page it renders, the tracker the whole history — so returning the
+   * in-flight promise would silently leave the second caller's activities
+   * unindexed. A pass with nothing stale costs one read and returns.
+   */
   function ensureIndex(activities: Activity[]): Promise<void> {
-    if (indexRequest) return indexRequest
-    indexRequest = buildIndex(activities).finally(() => {
-      indexRequest = null
-    })
-    return indexRequest
+    const next = indexRequest.catch(swallow).then(() => buildIndex(activities))
+    indexRequest = next
+    return next
   }
 
   return {
@@ -199,4 +271,28 @@ export function useActivityMetricsIndex() {
     progress,
     ensureIndex
   }
+}
+
+/**
+ * Keep the index in step with the activities a feed is showing.
+ *
+ * Indexing what is on screen rather than the whole history is what makes this
+ * affordable on the first screen: a page of ten costs ten targeted detail
+ * reads, and the next page pays for itself only once it is actually scrolled
+ * to. The cards read `derived` and render nothing for a row that is not there
+ * yet, so nothing ever waits on this.
+ */
+export function useFeedMetricsIndex<T extends Activity>(activities: Ref<T[]>): void {
+  const { ensureIndex } = useActivityMetricsIndex()
+
+  watch(
+    // The list is grown by `push`, so its identity never changes — watch the ids.
+    () => activities.value.map(a => a.id).join('|'),
+    () => {
+      // A friend's activity has no local details to derive anything from.
+      const own = activities.value.filter(a => !a.provider?.startsWith('friend_'))
+      if (own.length) void ensureIndex(own).catch(swallow)
+    },
+    { immediate: true }
+  )
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -718,7 +718,9 @@
     "distance": "Distance",
     "time": "Time",
     "pace": "Pace",
-    "speed": "Speed"
+    "speed": "Speed",
+    "elevation": "Elevation +",
+    "calories": "Calories"
   },
   "time": {
     "justNow": "just now",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -9,7 +9,9 @@
     "maxHr": "Max HR",
     "cadence": "Cadence",
     "calories": "Calories",
-    "avgSpeed": "Avg speed"
+    "avgSpeed": "Avg speed",
+    "elevationDown": "Elevation -",
+    "maxSpeed": "Max speed"
   },
   "sports": {
     "running": "Running",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -718,7 +718,9 @@
     "distance": "Distance",
     "time": "Temps",
     "pace": "Allure",
-    "speed": "Vitesse"
+    "speed": "Vitesse",
+    "elevation": "Dénivelé +",
+    "calories": "Calories"
   },
   "time": {
     "justNow": "à l'instant",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -9,7 +9,9 @@
     "maxHr": "FC max",
     "cadence": "Cadence",
     "calories": "Calories",
-    "avgSpeed": "Vitesse moy."
+    "avgSpeed": "Vitesse moy.",
+    "elevationDown": "Dénivelé -",
+    "maxSpeed": "Vitesse max"
   },
   "sports": {
     "running": "Course à pied",

--- a/src/services/ActivityAnalyzer.ts
+++ b/src/services/ActivityAnalyzer.ts
@@ -68,6 +68,46 @@ export class ActivityAnalyzer {
     return result
   }
 
+  /**
+   * Total climbed and descended, in metres.
+   *
+   * Barometric and GPS altitude jitter by a metre or two at rest, so summing
+   * every delta inflates both figures — a flat run can "climb" a hundred metres
+   * of noise. Only a run of movement that exceeds the threshold counts, which
+   * is the usual way devices compute these.
+   *
+   * Use the provider's own figures when it supplies them; this is for the ones
+   * that do not.
+   */
+  public elevationChange(): { ascent: number; descent: number } {
+    // 3 m, not 2: a barometer resting at ±1 m produces 2 m swings, which a
+    // threshold of 2 would count as real climb on a perfectly flat activity.
+    const THRESHOLD_M = 3
+
+    let ascent = 0
+    let descent = 0
+    let reference: number | null = null
+
+    for (const sample of this.samples) {
+      const elevation = sample.elevation
+      if (elevation == null || !Number.isFinite(elevation)) continue
+      if (reference === null) {
+        reference = elevation
+        continue
+      }
+      const diff = elevation - reference
+      if (diff >= THRESHOLD_M) {
+        ascent += diff
+        reference = elevation
+      } else if (diff <= -THRESHOLD_M) {
+        descent += -diff
+        reference = elevation
+      }
+    }
+
+    return { ascent: Math.round(ascent), descent: Math.round(descent) }
+  }
+
   private classifyByAccumulatedSlope(samples: Sample[]): 'up' | 'down' | 'flat' {
     let gain = 0
     let loss = 0

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -70,6 +70,8 @@ export interface ActivityDetails extends Timestamped {
     maxSpeed?: number
     averageCadence?: number
     totalAscent?: number
+    /** Metres descended — the twin of totalAscent, and the figure a skier reads. */
+    totalDescent?: number
     calories?: number
   }
   notes?: string

--- a/src/types/plugin-context.ts
+++ b/src/types/plugin-context.ts
@@ -210,6 +210,8 @@ export interface IAnalyzerFactory {
     sampleAverageByDistance(stepMeters: number): Sample[]
     sampleBySlopeChange(minDistanceMeters: number): Sample[]
     sampleByLaps(laps: { time: number }[]): Sample[]
+    /** Metres climbed and descended, noise-filtered. */
+    elevationChange(): { ascent: number; descent: number }
   }
 }
 

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -60,11 +60,16 @@ import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import ActivityCard from '@/components/ActivityCard.vue'
 import { useMixedFeed } from '@/composables/useMixedFeed'
+import { useFeedMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import { debounce } from '@/utils/debounce'
 
 const router = useRouter()
 const { t } = useI18n()
 const { activities, loading, hasMore, loadMore, reload, counts } = useMixedFeed()
+
+// Lifts calories, climb and the rest out of the details of the page on screen,
+// so the cards can show what only the details hold.
+useFeedMetricsIndex(activities)
 
 const scrollArea = ref<HTMLElement | null>(null)
 

--- a/src/views/MyActivities.vue
+++ b/src/views/MyActivities.vue
@@ -60,6 +60,7 @@ import type { Activity, ActivityFilters } from '@/types/activity'
 import { getActivityService, type ActivityServiceEvent } from '@/services/ActivityService'
 import { useSlotExtensions } from '@/composables/useSlotExtensions'
 import { useActivityFilters } from '@/composables/useActivityFilters'
+import { useFeedMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import { debounce } from '@/utils/debounce'
 
 const { t } = useI18n()
@@ -89,6 +90,10 @@ const pageSize = 10
 const hasMore = ref(true)
 const totalCount = ref(0)
 const availableSports = ref<string[]>([])
+
+// Lifts calories, climb and the rest out of the details of the page on screen,
+// so the cards can show what only the details hold.
+useFeedMetricsIndex(activities)
 
 // Store ActivityService instance for cleanup
 let activityServiceInstance: Awaited<ReturnType<typeof getActivityService>> | null = null

--- a/tests/unit/ActivityAnalyzer.spec.ts
+++ b/tests/unit/ActivityAnalyzer.spec.ts
@@ -46,3 +46,53 @@ describe('ActivityAnalyzer.sampleBySlopeChange', () => {
     expect(segs.length).toBeGreaterThan(0)
   })
 })
+
+describe('elevationChange', () => {
+  const withElevations = (elevations: number[]) =>
+    new ActivityAnalyzer(elevations.map((elevation, i) => ({ time: i, distance: i * 10, elevation })))
+
+  it('sums a clean climb and descent', () => {
+    // up 100, down 60
+    expect(withElevations([0, 50, 100, 70, 40]).elevationChange()).toEqual({
+      ascent: 100,
+      descent: 60
+    })
+  })
+
+  it('ignores the jitter a barometer produces at rest', () => {
+    // Ten minutes standing still, ±1 m of noise. Summing every delta would
+    // invent tens of metres of climb on a flat activity.
+    const noise = Array.from({ length: 200 }, (_, i) => 100 + (i % 2 ? 1 : -1))
+    const { ascent, descent } = withElevations(noise).elevationChange()
+    expect(ascent).toBe(0)
+    expect(descent).toBe(0)
+  })
+
+  it('still counts real movement hidden in noisy data', () => {
+    const climb = Array.from({ length: 100 }, (_, i) => i * 3 + (i % 2 ? 1 : -1))
+    expect(withElevations(climb).elevationChange().ascent).toBeGreaterThan(280)
+  })
+
+  it('reads a ski day as almost all descent', () => {
+    // Lifts are not recorded as climbing effort in this synthetic case: the
+    // shape is what matters — thousands down, little up.
+    const runs = [1800, 1200, 1750, 1150, 1700, 1100]
+    const { ascent, descent } = withElevations(runs).elevationChange()
+    expect(descent).toBeGreaterThan(ascent)
+    expect(descent).toBe(1800)
+  })
+
+  it('survives missing and non-finite elevations', () => {
+    const analyzer = new ActivityAnalyzer([
+      { time: 0, elevation: 100 },
+      { time: 1 },
+      { time: 2, elevation: NaN },
+      { time: 3, elevation: 150 }
+    ])
+    expect(analyzer.elevationChange()).toEqual({ ascent: 50, descent: 0 })
+  })
+
+  it('returns zeros with no samples at all', () => {
+    expect(new ActivityAnalyzer([]).elevationChange()).toEqual({ ascent: 0, descent: 0 })
+  })
+})

--- a/tests/unit/ActivityCard.units.spec.ts
+++ b/tests/unit/ActivityCard.units.spec.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import ActivityCard from '@/components/ActivityCard.vue'
 import { setUnitSystem } from '@/composables/useUnits'
+import { DERIVED, useActivityMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import en from '@/locales/en.json'
 import { createActivity } from '../fixtures/activities'
 
@@ -121,6 +122,65 @@ describe('ActivityCard — degenerate data', () => {
     const text = metrics(render({ type: 'running', distance: 0, duration: 1800 })).join(' | ')
     expect(text).not.toMatch(/Infinity|NaN/)
     expect(text).toContain('—')
+  })
+})
+
+describe('ActivityCard — values the scan lifted out of the details', () => {
+  const { derived } = useActivityMetricsIndex()
+
+  beforeEach(() => {
+    setUnitSystem('metric')
+    derived.value = new Map()
+  })
+
+  const scanned = (values: Record<string, number>) => {
+    derived.value = new Map([['activity-1', values]])
+  }
+
+  it('headlines the calories of a session that has no pace', () => {
+    // The card only holds an Activity, so before the scan this slot was empty.
+    scanned({ [DERIVED.calories]: 410 })
+    const text = metrics(render({ type: 'strength_training', distance: 0, duration: 3300 })).join(
+      ' | '
+    )
+    expect(text).toContain('410')
+    expect(text).toMatch(/Calories/i)
+  })
+
+  it('leaves the slot empty until the scan has reached the activity', () => {
+    const shown = metrics(render({ type: 'strength_training', distance: 0, duration: 3300 }))
+    expect(shown).toHaveLength(1) // time alone
+    expect(shown.join(' ')).not.toMatch(/Calories/i)
+  })
+
+  it('headlines the climb of a hike, as the detail page already did', () => {
+    scanned({ [DERIVED.ascent]: 870 })
+    const text = metrics(render({ type: 'hiking', distance: 12000, duration: 14400 })).join(' | ')
+    expect(text).toMatch(/Elevation/i)
+    expect(text).toContain('870')
+  })
+
+  it('falls back to a pace for a hike the scan has not reached', () => {
+    const text = metrics(render({ type: 'hiking', distance: 12000, duration: 14400 })).join(' | ')
+    expect(text).toMatch(/\/km/)
+  })
+
+  it('converts the lifted values like any other', () => {
+    // They are cached in SI precisely so the preference still applies.
+    setUnitSystem('imperial')
+    scanned({ [DERIVED.ascent]: 304.8 })
+    const text = metrics(render({ type: 'hiking', distance: 12000, duration: 14400 })).join(' | ')
+    expect(text).toContain('1000')
+    expect(text).toContain('ft')
+    setUnitSystem('metric')
+  })
+
+  it('does not headline calories for a sport that has a pace', () => {
+    // A run's accent slot belongs to its pace; the calories are detail-page work.
+    scanned({ [DERIVED.calories]: 600 })
+    const text = metrics(render({ type: 'running', distance: 10000, duration: 3000 })).join(' | ')
+    expect(text).toContain("5'00")
+    expect(text).not.toContain('600')
   })
 })
 

--- a/tests/unit/ActivityDetails.spec.ts
+++ b/tests/unit/ActivityDetails.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import { PLUGIN_CONTEXT_KEY } from '@/composables/usePluginContext'
+import { formatQuantity, convertQuantity, unitSystem } from '@/composables/useUnits'
 
 // Mock MapPreview component to prevent Leaflet/CSS fetch errors
 vi.mock('@/components/MapPreview.vue', () => ({
@@ -64,6 +66,32 @@ vi.mock('@/services/ActivityAnalyzer', () => ({
   }
 }))
 
+/**
+ * The view loads its widget slots asynchronously, and those widgets are plugins:
+ * they call `usePluginContext()` in setup and throw without it. Mounting the view
+ * without providing one only looked safe because the imports resolved after the
+ * test had returned — on a slower machine they land during the run and surface as
+ * an unhandled rejection, which fails the whole suite.
+ */
+const pluginContext = {
+  analyzer: {
+    create: () => ({
+      bestSegments: () => ({}),
+      sampleAverageByDistance: () => [],
+      sampleBySlopeChange: () => [],
+      sampleByLaps: () => [],
+      elevationChange: () => ({ ascent: 0, descent: 0 })
+    })
+  },
+  units: {
+    get system() {
+      return unitSystem.value
+    },
+    format: formatQuantity,
+    convert: convertQuantity
+  }
+}
+
 describe('ActivityDetails.vue', () => {
   it('monte sans erreur', async () => {
     const ActivityDetails = (await import('@/views/ActivityDetails.vue')).default
@@ -74,8 +102,17 @@ describe('ActivityDetails.vue', () => {
     router.push('/activity/test-123')
     await router.isReady()
     const wrapper = mount(ActivityDetails, {
-      global: { plugins: [router], stubs: ['RouterLink'] }
+      global: {
+        plugins: [router],
+        stubs: ['RouterLink'],
+        provide: { [PLUGIN_CONTEXT_KEY]: pluginContext }
+      }
     })
     expect(wrapper.exists()).toBe(true)
+
+    // Let the slot loaders resolve and their widgets mount, so a widget that
+    // throws fails this test rather than the suite that happens to run next.
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
   })
 })

--- a/tests/unit/plugins/ActivityTopBlock.spec.ts
+++ b/tests/unit/plugins/ActivityTopBlock.spec.ts
@@ -9,6 +9,15 @@ import { formatQuantity, unitSystem } from '@/composables/useUnits'
 const global = {
   provide: {
     [PLUGIN_CONTEXT_KEY]: {
+            analyzer: {
+        create: () => ({
+          elevationChange: () => ({ ascent: 0, descent: 0 }),
+          sampleAverageByDistance: () => [],
+          sampleByLaps: () => [],
+          sampleBySlopeChange: () => [],
+          bestSegments: () => ({})
+        })
+      },
       units: {
         get system() {
           return unitSystem.value

--- a/tests/unit/plugins/MetricIndex.spec.ts
+++ b/tests/unit/plugins/MetricIndex.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { Activity, ActivityDetails } from '@/types/activity'
-import type { ActivityMetricsRow } from '@/composables/useActivityMetricsIndex'
+import { INDEX_VERSION, type ActivityMetricsRow } from '@/composables/useActivityMetricsIndex'
 
 const mocks = vi.hoisted(() => ({
   getPluginContext: vi.fn()
@@ -11,8 +11,6 @@ vi.mock('@/services/PluginContextFactory', () => ({
 }))
 
 const { useActivityMetricsIndex } = await import('@/composables/useActivityMetricsIndex')
-
-const INDEX_VERSION = 1
 
 function makeActivity(id: string): Activity {
   return {
@@ -44,6 +42,7 @@ let storedRows: ActivityMetricsRow[]
 let addItemsToStore: ReturnType<typeof vi.fn>
 let getDetails: ReturnType<typeof vi.fn>
 let bestSegments: ReturnType<typeof vi.fn>
+let elevationChange: ReturnType<typeof vi.fn>
 
 /** Every target comes back at a plausible 5 min/km unless overridden */
 function defaultSegments(targets: number[]) {
@@ -61,6 +60,7 @@ function setupContext() {
   })
   getDetails = vi.fn(async (id: string) => makeDetails(id))
   bestSegments = vi.fn(defaultSegments)
+  elevationChange = vi.fn(() => ({ ascent: 640, descent: 610 }))
 
   mocks.getPluginContext.mockResolvedValue({
     storage: {
@@ -70,7 +70,7 @@ function setupContext() {
       addItemsToStore
     },
     activity: { getDetails },
-    analyzer: { create: () => ({ bestSegments }) }
+    analyzer: { create: () => ({ bestSegments, elevationChange }) }
   })
 }
 
@@ -174,5 +174,145 @@ describe('useActivityMetricsIndex', () => {
 
     expect(addItemsToStore).toHaveBeenCalledTimes(1)
     expect(storedRows).toHaveLength(2)
+  })
+
+  it('indexes every list, not just the first of a burst', async () => {
+    // The feed indexes the page it renders while the tracker asks for the whole
+    // history; returning the in-flight promise to the second caller used to drop
+    // its activities on the floor.
+    const { ensureIndex } = useActivityMetricsIndex()
+
+    await Promise.all([ensureIndex([makeActivity('a')]), ensureIndex([makeActivity('b')])])
+
+    expect(storedRows.map(r => r.id).sort()).toEqual(['a', 'b'])
+  })
+})
+
+describe('useActivityMetricsIndex — values lifted out of the details', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupContext()
+  })
+
+  const withStats = (stats: Record<string, number>) => {
+    getDetails.mockImplementation(async (id: string) => ({ ...makeDetails(id), stats }))
+    return useActivityMetricsIndex()
+  }
+
+  it('lifts the scalars a card cannot reach on its own', async () => {
+    // The feed card only ever holds an Activity; these all live in the details.
+    const { ensureIndex, derived } = withStats({
+      calories: 620,
+      maxSpeed: 5.4,
+      averageHeartRate: 148,
+      maxHeartRate: 181,
+      totalAscent: 430,
+      totalDescent: 410
+    })
+    await ensureIndex([makeActivity('a')])
+
+    expect(derived.value.get('a')).toMatchObject({
+      calories: 620,
+      maxSpeed: 5.4,
+      avgHeartRate: 148,
+      maxHeartRate: 181,
+      ascent: 430,
+      descent: 410
+    })
+  })
+
+  it('keeps them in SI, never in the reader units', async () => {
+    // A converted value in a derived cache would make the cache depend on a
+    // display preference — the invariant the records section already broke once.
+    const { ensureIndex, derived } = withStats({ maxSpeed: 5.4, totalAscent: 430 })
+    await ensureIndex([makeActivity('a')])
+
+    const values = derived.value.get('a')!
+    expect(values.maxSpeed).toBe(5.4) // m/s, not 19.4 km/h
+    expect(values.ascent).toBe(430) // m, not 1411 ft
+  })
+
+  it('recovers the climb from the samples when the provider reported none', async () => {
+    getDetails.mockImplementation(async (id: string) => ({
+      ...makeDetails(id),
+      samples: [
+        { time: 0, distance: 0, elevation: 1200 },
+        { time: 1500, distance: 5000, elevation: 1840 }
+      ],
+      stats: { calories: 300 }
+    }))
+
+    const { ensureIndex, derived } = useActivityMetricsIndex()
+    await ensureIndex([makeActivity('a')])
+
+    expect(derived.value.get('a')).toMatchObject({ ascent: 640, descent: 610 })
+  })
+
+  it('does not record a computed zero, which only means "nothing measured"', async () => {
+    // A climb that never comes back down. A reported 0 is the provider saying
+    // the ground was flat; a computed 0 says the trace stayed under the noise
+    // floor — the detail page already drops that rather than print "0 m".
+    elevationChange.mockReturnValue({ ascent: 590, descent: 0 })
+    getDetails.mockImplementation(async (id: string) => ({
+      ...makeDetails(id),
+      samples: [
+        { time: 0, distance: 0, elevation: 900 },
+        { time: 1500, distance: 5000, elevation: 1490 }
+      ],
+      stats: {}
+    }))
+
+    const { ensureIndex, derived } = useActivityMetricsIndex()
+    await ensureIndex([makeActivity('a')])
+
+    expect(derived.value.get('a')?.ascent).toBe(590)
+    expect(derived.value.get('a')?.descent).toBeUndefined()
+  })
+
+  it('keeps a descent the provider actually reported as zero', async () => {
+    const { ensureIndex, derived } = withStats({ totalAscent: 590, totalDescent: 0 })
+    await ensureIndex([makeActivity('a')])
+
+    expect(derived.value.get('a')?.descent).toBe(0)
+  })
+
+  it('prefers the reported climb over the computed one', async () => {
+    getDetails.mockImplementation(async (id: string) => ({
+      ...makeDetails(id),
+      samples: [
+        { time: 0, distance: 0, elevation: 1200 },
+        { time: 1500, distance: 5000, elevation: 1840 }
+      ],
+      stats: { totalAscent: 655, totalDescent: 655 }
+    }))
+
+    const { ensureIndex, derived } = useActivityMetricsIndex()
+    await ensureIndex([makeActivity('a')])
+
+    expect(elevationChange).not.toHaveBeenCalled()
+    expect(derived.value.get('a')).toMatchObject({ ascent: 655, descent: 655 })
+  })
+
+  it('leaves out what the activity does not have', async () => {
+    // A gym session has calories and a heart rate, and no elevation at all.
+    const { ensureIndex, derived } = withStats({ calories: 410, averageHeartRate: 118 })
+    getDetails.mockImplementation(async (id: string) => ({
+      id,
+      samples: [{ time: 0, heartRate: 118 }],
+      stats: { calories: 410, averageHeartRate: 118 }
+    }))
+    await ensureIndex([makeActivity('a')])
+
+    const values = derived.value.get('a')!
+    expect(values.calories).toBe(410)
+    expect(values.ascent).toBeUndefined()
+    expect(values.maxSpeed).toBeUndefined()
+  })
+
+  it('still records the best times alongside them', async () => {
+    const { ensureIndex, derived } = withStats({ calories: 620 })
+    await ensureIndex([makeActivity('a')])
+
+    expect(derived.value.get('a')?.time_5000).toBe(1500)
   })
 })

--- a/tests/unit/plugins/PersonalRecords.spec.ts
+++ b/tests/unit/plugins/PersonalRecords.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ref } from 'vue'
 import type { Activity } from '@/types/activity'
 import type { RecordPeriod } from '@plugins/app-extensions/Statistics/types'
-import type { ActivityMetricsRow } from '@/composables/useActivityMetricsIndex'
+import { INDEX_VERSION, type ActivityMetricsRow } from '@/composables/useActivityMetricsIndex'
 
 const mocks = vi.hoisted(() => ({
   getPluginContext: vi.fn()
@@ -55,7 +55,7 @@ let deleteData: ReturnType<typeof vi.fn>
 let exportDB: ReturnType<typeof vi.fn>
 
 function row(id: string, startTime: number, values: Record<string, number>): ActivityMetricsRow {
-  return { id, startTime, sport: 'running', indexVersion: 1, values }
+  return { id, startTime, sport: 'running', indexVersion: INDEX_VERSION, values }
 }
 
 function setupContext() {

--- a/tests/unit/widgets.ActivityTopBlock.spec.ts
+++ b/tests/unit/widgets.ActivityTopBlock.spec.ts
@@ -21,6 +21,37 @@ function makeData(over: Record<string, unknown> = {}) {
 
 // The widget formats through the plugin context, as plugins must.
 const pluginContext = {
+    analyzer: {
+    create: (samples: { elevation?: number }[]) => ({
+      // The real computation, so the fallback path is genuinely exercised.
+      elevationChange: () => {
+        let ascent = 0
+        let descent = 0
+        let ref: number | null = null
+        for (const sample of samples ?? []) {
+          const e = sample.elevation
+          if (e == null || !Number.isFinite(e)) continue
+          if (ref === null) {
+            ref = e
+            continue
+          }
+          const d = e - ref
+          if (d >= 3) {
+            ascent += d
+            ref = e
+          } else if (d <= -3) {
+            descent += -d
+            ref = e
+          }
+        }
+        return { ascent: Math.round(ascent), descent: Math.round(descent) }
+      },
+      sampleAverageByDistance: () => [],
+      sampleByLaps: () => [],
+      sampleBySlopeChange: () => [],
+      bestSegments: () => ({})
+    })
+  },
   units: {
     get system() {
       return unitSystem.value
@@ -107,5 +138,55 @@ describe('ActivityTopBlock — sports without a pace', () => {
     }).text()
     expect(text).toMatch(/Avg pace/i)
     expect(text).toContain('600')
+  })
+})
+
+describe('ActivityTopBlock — descent and max speed', () => {
+  beforeEach(() => setUnitSystem('metric'))
+
+  const ski = (over: Record<string, unknown> = {}) =>
+    render({
+      ...makeData({ type: 'alpine_skiing', distance: 31200, duration: 10800 }),
+      details: {
+        id: 'a1',
+        samples: [
+          { time: 0, elevation: 1800 },
+          { time: 1, elevation: 1200 },
+          { time: 2, elevation: 1750 },
+          { time: 3, elevation: 1100 }
+        ],
+        stats: { averageSpeed: 2.9, maxSpeed: 21.4, totalAscent: 550, ...over }
+      }
+    })
+
+  it('prefers the descent the provider reported', () => {
+    expect(ski({ totalDescent: 4200 }).text()).toMatch(/4\s?200\s*m|4200\s*m/)
+  })
+
+  it('computes the descent when the provider gave none', () => {
+    // Every activity stored before this existed falls here.
+    const text = ski().text()
+    expect(text).toMatch(/Elevation -|Dénivelé/i)
+    expect(text).toMatch(/1250/)
+  })
+
+  it('shows the max speed, which was stored and displayed nowhere', () => {
+    expect(ski().text()).toMatch(/77\.0\s*km\/h/)
+  })
+
+  it('omits the descent when there is no elevation at all', () => {
+    const flat = render({
+      ...makeData({ type: 'running' }),
+      details: { id: 'a1', samples: [{ time: 0, heartRate: 150 }], stats: { averageSpeed: 3 } }
+    })
+    expect(flat.text()).not.toMatch(/Elevation -|Dénivelé -/i)
+  })
+
+  it('follows the unit preference for both', () => {
+    setUnitSystem('imperial')
+    const text = ski({ totalDescent: 1000 }).text()
+    expect(text).toMatch(/3281\s*ft/)
+    expect(text).toMatch(/mph/)
+    setUnitSystem('metric')
   })
 })

--- a/tests/unit/widgets.ActivityTopBlock.spec.ts
+++ b/tests/unit/widgets.ActivityTopBlock.spec.ts
@@ -3,8 +3,19 @@ import { mount } from '@vue/test-utils'
 import ActivityTopBlock from '@plugins/app-extensions/StandardDetails/ActivityTopBlock.vue'
 import { PLUGIN_CONTEXT_KEY } from '@/composables/usePluginContext'
 import { formatQuantity, setUnitSystem, unitSystem } from '@/composables/useUnits'
+import type { Activity, ActivityDetails } from '@/types/activity'
 
-function makeData(over: Record<string, unknown> = {}) {
+// Typed rather than inferred: an inferred literal narrows `stats` to the three
+// keys this default happens to carry and `samples` to `never[]`, so every test
+// below that overrides them stops compiling.
+type WidgetData = { activity: Activity; details: ActivityDetails }
+
+type Stats = NonNullable<ActivityDetails['stats']>
+
+function makeData(
+  over: Partial<Activity> = {},
+  detailsOver: Partial<ActivityDetails> = {}
+): WidgetData {
   return {
     activity: {
       id: 'a1',
@@ -13,15 +24,24 @@ function makeData(over: Record<string, unknown> = {}) {
       duration: 1500,
       startTime: Math.floor(Date.now() / 1000),
       provider: 'mock',
+      version: 1,
+      lastModified: Date.now(),
       ...over
     },
-    details: { id: 'a1', stats: { totalAscent: 120, averageSpeed: 3, calories: 400 }, samples: [] }
+    details: {
+      id: 'a1',
+      version: 1,
+      lastModified: Date.now(),
+      stats: { totalAscent: 120, averageSpeed: 3, calories: 400 },
+      samples: [],
+      ...detailsOver
+    }
   }
 }
 
 // The widget formats through the plugin context, as plugins must.
 const pluginContext = {
-    analyzer: {
+  analyzer: {
     create: (samples: { elevation?: number }[]) => ({
       // The real computation, so the fallback path is genuinely exercised.
       elevationChange: () => {
@@ -60,7 +80,7 @@ const pluginContext = {
   }
 }
 
-const render = (data = makeData()) =>
+const render = (data: WidgetData = makeData()) =>
   mount(ActivityTopBlock, {
     props: { data },
     global: { provide: { [PLUGIN_CONTEXT_KEY]: pluginContext } }
@@ -104,14 +124,12 @@ describe('ActivityTopBlock — sports without a pace', () => {
   beforeEach(() => setUnitSystem('metric'))
 
   const gym = () =>
-    render({
-      ...makeData({ type: 'strength_training', distance: 0, duration: 3300 }),
-      details: {
-        id: 'a1',
-        stats: { averageHeartRate: 118, maxHeartRate: 158, calories: 410 },
-        samples: []
-      }
-    })
+    render(
+      makeData(
+        { type: 'strength_training', distance: 0, duration: 3300 },
+        { stats: { averageHeartRate: 118, maxHeartRate: 158, calories: 410 }, samples: [] }
+      )
+    )
 
   it('headlines calories when there is no pace or speed to show', () => {
     // The accent slot used to hold a dash while the calories sat in the second row.
@@ -132,10 +150,9 @@ describe('ActivityTopBlock — sports without a pace', () => {
   })
 
   it('still keeps calories in the second row for a run', () => {
-    const text = render({
-      ...makeData({ type: 'running' }),
-      details: { id: 'a1', stats: { averageSpeed: 3, calories: 600 }, samples: [] }
-    }).text()
+    const text = render(
+      makeData({ type: 'running' }, { stats: { averageSpeed: 3, calories: 600 }, samples: [] })
+    ).text()
     expect(text).toMatch(/Avg pace/i)
     expect(text).toContain('600')
   })
@@ -144,20 +161,21 @@ describe('ActivityTopBlock — sports without a pace', () => {
 describe('ActivityTopBlock — descent and max speed', () => {
   beforeEach(() => setUnitSystem('metric'))
 
-  const ski = (over: Record<string, unknown> = {}) =>
-    render({
-      ...makeData({ type: 'alpine_skiing', distance: 31200, duration: 10800 }),
-      details: {
-        id: 'a1',
-        samples: [
-          { time: 0, elevation: 1800 },
-          { time: 1, elevation: 1200 },
-          { time: 2, elevation: 1750 },
-          { time: 3, elevation: 1100 }
-        ],
-        stats: { averageSpeed: 2.9, maxSpeed: 21.4, totalAscent: 550, ...over }
-      }
-    })
+  const ski = (over: Partial<Stats> = {}) =>
+    render(
+      makeData(
+        { type: 'alpine_skiing', distance: 31200, duration: 10800 },
+        {
+          samples: [
+            { time: 0, elevation: 1800 },
+            { time: 1, elevation: 1200 },
+            { time: 2, elevation: 1750 },
+            { time: 3, elevation: 1100 }
+          ],
+          stats: { averageSpeed: 2.9, maxSpeed: 21.4, totalAscent: 550, ...over }
+        }
+      )
+    )
 
   it('prefers the descent the provider reported', () => {
     expect(ski({ totalDescent: 4200 }).text()).toMatch(/4\s?200\s*m|4200\s*m/)
@@ -175,10 +193,12 @@ describe('ActivityTopBlock — descent and max speed', () => {
   })
 
   it('omits the descent when there is no elevation at all', () => {
-    const flat = render({
-      ...makeData({ type: 'running' }),
-      details: { id: 'a1', samples: [{ time: 0, heartRate: 150 }], stats: { averageSpeed: 3 } }
-    })
+    const flat = render(
+      makeData(
+        { type: 'running' },
+        { samples: [{ time: 0, heartRate: 150 }], stats: { averageSpeed: 3 } }
+      )
+    )
     expect(flat.text()).not.toMatch(/Elevation -|Dénivelé -/i)
   })
 


### PR DESCRIPTION
Deux commits, la même idée : rendre lisible ce qui était stocké mais invisible.

## `feat(details)` — dénivelé négatif et vitesse max

La page de détail affichait le D+ mais jamais le D−, et jamais la vitesse max —
pourtant écrite par tous les providers depuis le début. Une journée de ski
grimpe presque rien et descend des milliers de mètres : c'est ce chiffre-là que
le skieur lit.

Le D− vient du provider quand il le déclare, sinon il est recalculé depuis la
trace barométrique via `ActivityAnalyzer.elevationChange()` (seuil 3 m, pour ne
pas compter le bruit d'un baromètre au repos comme du dénivelé réel).

## `feat(scan)` — les valeurs des détails atteignent enfin les cards

Une card de feed ne reçoit qu'un `Activity`. Les calories, le dénivelé et le
reste vivent dans `ActivityDetails`, dont les samples sont bien trop lourds pour
être chargés card par card. Résultat : une séance de renfo n'affichait que sa
durée, et une rando se rabattait sur une allure dont elle n'a aucun usage.

`activity_metrics` existait déjà exactement pour ça — un cache local à
l'appareil, recalculable, avec un sac `values` ouvert qui ne contenait jusqu'ici
que les meilleurs temps. `computeValues()` devient le seul endroit où les
détails sont lus pour l'index, et y ajoute les scalaires `DERIVED` : calories,
D+, D−, vitesse max, fréquences cardiaques — en SI comme tout le reste.

| Card | Avant | Après |
| --- | --- | --- |
| Renfo (3300 s) | `TIME 55:00` seul | `TIME 55:00 · CALORIES 410 kcal` |
| Rando (D+ déclaré) | `PACE 12'00/km` | `ELEVATION + 870 m` |
| Rando (D+ absent) | `PACE 12'00/km` | `ELEVATION + 580 m`, recalculé |
| Sortie longue | `PACE 5'00/km` | inchangé — les calories ne volent pas l'accent |
| Yoga sans calories | `TIME` seul | inchangé — pas de tiret |

### Le scan suit le feed, pas l'historique

`useFeedMetricsIndex(activities)` n'indexe **que la page affichée** : le premier
écran coûte dix lectures ciblées de détails au lieu du store entier, et la page
suivante ne se paie qu'une fois scrollée. Une card sans ligne d'index rend sans
la valeur et se remplit quand elle arrive — rien n'attend jamais le scan.

### Trois points de détail qui comptent

- `ensureIndex` **sérialise** au lieu de coalescer : le feed et le metric tracker
  passent des listes différentes, et renvoyer la promesse en vol laissait les
  activités du second appelant non indexées.
- Un dénivelé **calculé** à 0 n'est pas stocké. Contrairement à un 0 déclaré par
  le provider — qui affirme que c'était plat — il dit seulement que la trace n'a
  jamais dépassé le seuil de bruit.
- `INDEX_VERSION` passe à 2 (les lignes existantes se recalculent d'elles-mêmes)
  et devient exporté, pour que les tests cessent de le dupliquer.

## Vérifications

- 596 tests unitaires verts (+24), lint et build propres
- Rendu contrôlé dans un vrai navigateur sur les cinq cas du tableau, plus le
  hero carte des randos (présent avec tracé, absent sans — la règle §9 inchangée)
- Documenté : `docs/SPORT_AND_UNITS.md` §10 bis (« afficher sur une card une
  valeur qui vit dans les détails ») et la section « Device-local stores » de
  `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH


---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_