### PR TITLE
feat(install): proposer l'installation de la PWA, au moment où ça aide encore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ that stored converted numbers would depend on a display preference. See
 - Plugin architecture: `docs/PLUGIN_GUIDELINES.md`
 - Technical roadmap: `docs/ROADMAP_TECHNIQUE.md`
 - Deployment: `docs/DEPLOYMENT.md`
+- Install funnel (PWA, per-platform timing): `docs/INSTALL_FUNNEL.md`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ that stored converted numbers would depend on a display preference. See
 - Technical roadmap: `docs/ROADMAP_TECHNIQUE.md`
 - Deployment: `docs/DEPLOYMENT.md`
 - Install funnel (PWA, per-platform timing): `docs/INSTALL_FUNNEL.md`
+- Native app (Capacitor, health plugins) — read before starting: `docs/NATIVE_APP.md`
 
 ---
 

--- a/docs/INSTALL_FUNNEL.md
+++ b/docs/INSTALL_FUNNEL.md
@@ -1,0 +1,58 @@
+# Proposer l'installation — quel moment, quelle plateforme
+
+Le tunnel d'installation est **asymétrique entre iOS et Android**, et ce n'est pas
+un caprice : les deux plateformes ne stockent pas les données au même endroit.
+
+## La contrainte qui commande tout
+
+**Sur iOS, une app ajoutée à l'écran d'accueil a son propre conteneur de
+stockage.** Rien n'est copié depuis Safari. Un athlète qui connecte Garmin dans
+le navigateur, importe 400 activités, puis installe la PWA **ouvre une app
+vide**.
+
+Sur Android, l'app installée partage le stockage du navigateur. Le problème
+n'existe pas.
+
+## La règle
+
+| Plateforme             | Quand on propose                                                    | Pourquoi                                                             |
+| ---------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| iOS Safari             | **avant** tout branchement de plugin                                | installer après ferait perdre l'import                               |
+| Android Chromium       | après engagement : ≥ 4 jours distincts **et** au moins une activité | stockage partagé, on peut attendre que l'usage se confirme           |
+| Chrome/Firefox iOS     | jamais                                                              | ils ne savent pas ajouter à l'écran d'accueil ; guider serait mentir |
+| Desktop, déjà installé | jamais                                                              | rien à proposer                                                      |
+
+## Où c'est écrit
+
+- `src/services/InstallService.ts` — plateforme, capture de l'événement, état
+- `src/composables/useInstallPrompt.ts` — **la règle ci-dessus**, et rien d'autre
+- `src/components/InstallPrompt.vue` — les deux variantes d'affichage
+
+## Le piège technique
+
+`beforeinstallprompt` **ne se déclenche qu'une fois, pendant le chargement**, et
+seulement sur Chromium. Sans `preventDefault()` et une référence gardée, il est
+perdu et `prompt()` ne pourra plus jamais être appelé.
+
+C'est pour cela que `InstallService.initialize()` est appelé dans `main.ts`
+**avant le montage de l'app**, et pas depuis un composant. Ne pas déplacer.
+
+Sur iOS il n'existe aucune API : on ne peut que montrer où se trouve le geste
+(Partager → Sur l'écran d'accueil). D'où les deux variantes du composant.
+
+## Ne pas harceler
+
+Deux refus (`dismissCount >= 2`) et on arrête définitivement de proposer.
+L'état vit dans `install_prompt_state` — c'est de l'état applicatif qui pilote
+une décision, **pas de la mesure** : l'app n'a pas de télémétrie, et un compteur
+local ne pourrait de toute façon rien agréger.
+
+Le compte de visites est **par jour distinct**, pas par ouverture : quatre
+rechargements dans la même session ne disent rien d'une habitude.
+
+## App native
+
+Pas de lien vers les stores tant qu'il n'y a rien dessus. Le jour où une app
+Capacitor existe, HealthKit et Health Connect entrent tels quels dans le contrat
+`ProviderPlugin` — un dossier par plateforme dans `plugins/data-providers/`,
+sans toucher au core.

--- a/docs/INSTALL_FUNNEL.md
+++ b/docs/INSTALL_FUNNEL.md
@@ -52,7 +52,7 @@ rechargements dans la même session ne disent rien d'une habitude.
 
 ## App native
 
-Pas de lien vers les stores tant qu'il n'y a rien dessus. Le jour où une app
-Capacitor existe, HealthKit et Health Connect entrent tels quels dans le contrat
-`ProviderPlugin` — un dossier par plateforme dans `plugins/data-providers/`,
-sans toucher au core.
+Pas de lien vers les stores tant qu'il n'y a rien dessus. Quand le wrapper
+Capacitor sera fait, **lire `docs/NATIVE_APP.md` avant de commencer** : il
+recense les pièges, dont deux qui touchent directement ce tunnel (le WebView iOS
+se présente comme Safari, et le stockage repart de zéro une fois de plus).

--- a/docs/NATIVE_APP.md
+++ b/docs/NATIVE_APP.md
@@ -1,0 +1,127 @@
+# App native (Capacitor) — guide pour l'agent qui la fera
+
+Ce document existe pour que la personne — ou l'agent — qui attaquera le wrapper
+natif ne redécouvre pas les pièges à ses dépens. Rien de ceci n'est encore fait.
+
+> Contexte : `docs/INSTALL_FUNNEL.md` explique pourquoi le tunnel d'installation
+> PWA ne propose aucun lien vers les stores aujourd'hui.
+
+## Pourquoi Capacitor
+
+L'app est déjà une PWA Vue complète. Capacitor l'emballe **sans réécriture** :
+le même `dist/` est servi dans un WebView, et les API natives arrivent par des
+plugins JS. React Native ou Flutter voudraient dire tout refaire.
+
+Ce qui apparaît : `capacitor.config.ts`, `ios/`, `android/`. Ce qui ne change
+pas : `src/`, `plugins/`, le build Vite.
+
+## L'essentiel : santé = plugin de données, pas de modification du core
+
+HealthKit et Health Connect entrent **tels quels** dans le contrat existant.
+
+```
+plugins/data-providers/AppleHealth/client/index.ts     → ProviderPlugin
+plugins/data-providers/HealthConnect/client/index.ts   → ProviderPlugin
+```
+
+L'adaptateur produit des `Activity` / `ActivityDetails` en SI, comme Garmin et
+Strava. `checkActivityContract` (voir `src/services/activityContract.ts`) les
+contrôle à la même porte, sans qu'on ait à l'inscrire nulle part.
+
+Le mapping des sports se calque sur `GarminProvider/client/sportTypes.ts` :
+`HKWorkoutActivityType` (iOS) et `ExerciseSessionRecord` (Android) → `SportType`
+canonique, inconnu → `'other'`.
+
+**Ne rien ajouter à `ActivityDetails.stats`** pour une donnée propre à une
+plateforme : passer par `MEASUREMENT_KEYS` / `MEASUREMENTS`
+(`docs/SPORT_AND_UNITS.md` §7).
+
+## Les quatre pièges
+
+### 1. Le registre de plugins est _eager_
+
+```ts
+// src/services/ProviderPluginRegistry.ts
+const modules = import.meta.glob('@plugins/data-providers/**/client/index.ts', { eager: true })
+```
+
+Un plugin santé sera donc **découvert et exécuté dans le build web**, où
+`@capacitor/...` n'existe pas. Deux conséquences :
+
+- L'`index.ts` du plugin ne doit **jamais** importer un module Capacitor au
+  niveau du module. L'import va dans `setupComponent()` / `refreshData()`, en
+  dynamique (`await import(...)`).
+- Il faut pouvoir le masquer sur les plateformes où il n'a pas de sens. Ajouter
+  à `ProviderPlugin` un champ jumeau de `deprecated`, filtré au même endroit :
+
+```ts
+/** Plateformes où ce provider a un sens. Absent = partout. */
+availableOn?: Array<'web' | 'ios' | 'android'>
+```
+
+et l'appliquer dans `installableProviderPlugins`. Garder `allProviderPlugins`
+complet, pour la même raison que `deprecated` : une activité déjà importée doit
+continuer à résoudre son provider.
+
+### 2. Le WebView iOS se présente comme Safari
+
+`InstallService.platform` (`src/services/InstallService.ts`) lit l'user-agent.
+Dans un WKWebView Capacitor, il ressemble à Safari iOS — donc le tunnel
+**proposerait d'installer la PWA depuis l'app native déjà installée**.
+
+Il faut une branche `'native'` avant toute autre détection :
+
+```ts
+import { Capacitor } from '@capacitor/core'
+if (Capacitor.isNativePlatform()) return 'native'
+```
+
+et `canInstall` doit valoir `false` pour elle. Les tests de
+`tests/unit/InstallService.spec.ts` sont le bon endroit pour verrouiller ça.
+
+### 3. Le stockage repart de zéro — encore
+
+C'est le même problème que celui décrit dans `docs/INSTALL_FUNNEL.md`, un cran
+plus loin : le WebView natif a **son propre conteneur IndexedDB**. Un utilisateur
+qui passe de la PWA à l'app native ouvre une app vide.
+
+La seule sortie propre est celle qui existe déjà : un storage provider connecté,
+et `ctx.storage.importFromRemote()` au premier lancement pour réhydrater. Le
+parcours de première ouverture de l'app native doit donc proposer la connexion
+cloud **avant** toute autre chose, et non l'import santé.
+
+### 4. Le service worker n'a plus de rôle
+
+L'app native sert son bundle depuis le disque. `PWAUpdateService` (36 tests) ne
+doit pas proposer de mise à jour dans ce contexte — la mise à jour passe par le
+store. Vérifier son comportement sous `Capacitor.isNativePlatform()` avant de
+livrer, sinon l'utilisateur voit une invite à recharger qui ne fait rien.
+
+## Ce qu'un agent ne peut pas faire
+
+Ces étapes demandent un humain avec des comptes et une carte bancaire :
+
+- **Apple** : compte développeur (99 $/an), entitlement HealthKit, chaînes de
+  confidentialité `NSHealthShareUsageDescription` /
+  `NSHealthUpdateUsageDescription`. Les apps HealthKit passent une revue
+  renforcée : Apple refuse celles qui n'expliquent pas clairement l'usage des
+  données.
+- **Google** : Play Console, déclaration Health Connect (formulaire séparé, avec
+  justification par type de donnée demandé), politique de confidentialité
+  publiée.
+
+Prévoir que la première soumission soit refusée. Ce n'est pas un échec, c'est le
+déroulé normal.
+
+## Ordre de travail suggéré
+
+1. Capacitor autour du build existant, sans aucune API native — vérifier que
+   l'app tourne dans les deux WebViews.
+2. Piège 2 (branche `'native'` d'`InstallService`) et piège 4 (service worker),
+   qui sont des régressions visibles dès cette étape.
+3. `availableOn` sur `ProviderPlugin` et son filtrage.
+4. Un seul plugin santé, complet, testé — Health Connect d'abord, la revue
+   Google étant plus rapide qu'Apple.
+5. Le second plugin.
+6. Rouvrir la carte « app mobile » du tunnel d'installation, une fois qu'il y a
+   vraiment quelque chose sur un store.

--- a/src/components/InstallPrompt.vue
+++ b/src/components/InstallPrompt.vue
@@ -1,0 +1,239 @@
+<template>
+  <section v-if="visible" class="iprompt" :class="`iprompt--${variant}`" data-test="install-prompt">
+    <button
+      v-if="variant === 'banner'"
+      class="iprompt__close"
+      :title="t('common.cancel')"
+      data-test="install-dismiss"
+      @click="onDismiss"
+    >
+      <i class="fas fa-xmark" aria-hidden="true"></i>
+    </button>
+
+    <div class="iprompt__head">
+      <div class="iprompt__badge">
+        <i class="fas fa-mobile-screen-button" aria-hidden="true"></i>
+      </div>
+      <div>
+        <h3 class="iprompt__title">{{ t('install.title') }}</h3>
+        <p class="iprompt__subtitle">{{ subtitle }}</p>
+      </div>
+    </div>
+
+    <!-- Android: the browser owns the dialog, we just ask for it -->
+    <button v-if="canPrompt" class="iprompt__cta" data-test="install-cta" @click="onInstall">
+      <i class="fas fa-download" aria-hidden="true"></i>
+      {{ t('install.action') }}
+    </button>
+
+    <!-- iOS: nothing can be triggered, so show where the gesture lives -->
+    <ol v-else class="iprompt__steps" data-test="install-steps">
+      <li>
+        <i class="fas fa-arrow-up-from-bracket" aria-hidden="true"></i>
+        <span>{{ t('install.ios.share') }}</span>
+      </li>
+      <li>
+        <i class="fas fa-square-plus" aria-hidden="true"></i>
+        <span>{{ t('install.ios.addToHome') }}</span>
+      </li>
+      <li>
+        <i class="fas fa-check" aria-hidden="true"></i>
+        <span>{{ t('install.ios.confirm') }}</span>
+      </li>
+    </ol>
+
+    <button
+      v-if="variant === 'gate'"
+      class="iprompt__skip"
+      data-test="install-skip"
+      @click="onDismiss"
+    >
+      {{ t('install.later') }}
+    </button>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useInstallPrompt } from '@/composables/useInstallPrompt'
+
+const props = withDefaults(
+  defineProps<{
+    /**
+     * `gate` precedes connecting anything (iOS) and explains what is at stake;
+     * `banner` is the discreet strip shown to an Android user already using the app.
+     */
+    variant?: 'gate' | 'banner'
+  }>(),
+  { variant: 'banner' }
+)
+
+const { t } = useI18n()
+const { canPrompt, offerBeforePlugins, offerAfterEngagement, promptInstall, dismiss } =
+  useInstallPrompt()
+
+const visible = computed(() =>
+  props.variant === 'gate' ? offerBeforePlugins.value : offerAfterEngagement.value
+)
+
+/**
+ * The reason differs, so the sentence does too. On iOS the point is that the
+ * order matters — installing later means re-importing everything.
+ */
+const subtitle = computed(() =>
+  props.variant === 'gate' ? t('install.ios.subtitle') : t('install.subtitle')
+)
+
+const onInstall = () => promptInstall()
+const onDismiss = () => dismiss()
+</script>
+
+<style scoped>
+.iprompt {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius-lg);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  color: var(--color-ink);
+}
+
+.iprompt--gate {
+  border-color: var(--color-green-200);
+  background: var(--color-green-50);
+}
+
+.iprompt--banner {
+  margin: 0 0 14px;
+  box-shadow: var(--shadow-float);
+}
+
+.iprompt__head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Keep the title clear of the close button, which floats over this row */
+.iprompt--banner .iprompt__head {
+  padding-right: 28px;
+}
+
+.iprompt__badge {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+  font-size: 18px;
+}
+
+.iprompt__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.iprompt__subtitle {
+  margin: 2px 0 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-faint);
+}
+
+.iprompt__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--color-green-600);
+  color: var(--color-white);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.iprompt__cta:hover {
+  background: var(--color-green-700);
+}
+
+.iprompt__steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  counter-reset: step;
+}
+
+.iprompt__steps li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  counter-increment: step;
+}
+
+.iprompt__steps li::before {
+  content: counter(step);
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--color-green-600);
+  color: var(--color-white);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.iprompt__steps i {
+  color: var(--color-green-700);
+  width: 18px;
+  text-align: center;
+}
+
+.iprompt__skip,
+.iprompt__close {
+  background: none;
+  border: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.iprompt__skip {
+  align-self: center;
+  padding: 4px 8px;
+  text-decoration: underline;
+}
+
+.iprompt__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  padding: 4px 8px;
+  font-size: 15px;
+}
+
+.iprompt__close:hover,
+.iprompt__skip:hover {
+  color: var(--color-ink);
+}
+</style>

--- a/src/components/profile/ProfileDataSources.vue
+++ b/src/components/profile/ProfileDataSources.vue
@@ -1,5 +1,7 @@
 <template>
   <div class="space-y-6">
+    <InstallPrompt variant="gate" class="mb-6" />
+
     <h2 class="text-2xl font-bold">{{ t('dataProviders.title') }}</h2>
 
     <!-- Connected Providers -->
@@ -67,6 +69,7 @@
 </template>
 
 <script setup lang="ts">
+import InstallPrompt from '@/components/InstallPrompt.vue'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { installableProviderPlugins } from '@/services/ProviderPluginRegistry'

--- a/src/composables/useInstallPrompt.ts
+++ b/src/composables/useInstallPrompt.ts
@@ -1,0 +1,81 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import {
+  getInstallService,
+  ANDROID_MIN_VISIT_DAYS,
+  type InstallPlatform
+} from '@/services/InstallService'
+import { DataProviderPluginManager } from '@/services/DataProviderPluginManager'
+import { StoragePluginManager } from '@/services/StoragePluginManager'
+import { getActivityService } from '@/services/ActivityService'
+
+/**
+ * When to invite the user to install, which is not the same question on the two
+ * platforms — and the asymmetry is forced by how they store data.
+ *
+ * **iOS**: a web app added to the home screen gets its own storage container.
+ * Nothing is copied over from Safari, so an athlete who connects Garmin in the
+ * browser and installs afterwards opens an empty app. The invitation therefore
+ * has to come *before* any provider is connected, so every import lands in the
+ * installed app from the start.
+ *
+ * **Android**: the installed app shares the browser's storage, so nothing is
+ * lost by waiting. We wait for the habit to show instead — several distinct
+ * days of use, and activities actually imported.
+ */
+export function useInstallPrompt() {
+  const service = getInstallService()
+
+  const platform = ref<InstallPlatform>(service.platform)
+  const canPrompt = ref(service.canPrompt)
+
+  /** iOS, before anything is connected: install first or lose the import. */
+  const offerBeforePlugins = ref(false)
+  /** Android, once the app has proven useful. */
+  const offerAfterEngagement = ref(false)
+
+  const refresh = async () => {
+    platform.value = service.platform
+    canPrompt.value = service.canPrompt
+
+    offerBeforePlugins.value = false
+    offerAfterEngagement.value = false
+
+    if (!service.canInstall || !service.mayAsk) return
+
+    if (platform.value === 'ios-safari') {
+      const providers = await DataProviderPluginManager.getInstance().getEnabledPlugins()
+      const storages = await StoragePluginManager.getInstance().getEnabledPlugins()
+      offerBeforePlugins.value = providers.length === 0 && storages.length === 0
+      return
+    }
+
+    if (platform.value === 'android-chromium') {
+      if (service.visitDays < ANDROID_MIN_VISIT_DAYS) return
+      const activities = await (await getActivityService()).getAllActivities()
+      offerAfterEngagement.value = activities.some(a => !a.deleted)
+    }
+  }
+
+  const onAvailabilityChanged = () => {
+    void refresh()
+  }
+
+  onMounted(() => {
+    service.emitter.addEventListener('availability-changed', onAvailabilityChanged)
+    void refresh()
+  })
+
+  onUnmounted(() => {
+    service.emitter.removeEventListener('availability-changed', onAvailabilityChanged)
+  })
+
+  return {
+    platform,
+    canPrompt,
+    offerBeforePlugins,
+    offerAfterEngagement,
+    promptInstall: () => service.promptInstall(),
+    dismiss: () => service.recordDismissal(),
+    refresh
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -798,5 +798,17 @@
     "tempo": "Tempo",
     "endurance": "Endurance",
     "recovery": "Recovery"
+  },
+  "install": {
+    "title": "Add OpenStride to your home screen",
+    "subtitle": "Opens instantly, works offline, and keeps its own space on your phone.",
+    "action": "Install",
+    "later": "Not now",
+    "ios": {
+      "subtitle": "Install it before connecting a source: on iPhone a home-screen app keeps its own data, so anything imported in Safari would stay behind.",
+      "share": "Tap Share in the Safari toolbar",
+      "addToHome": "Choose \"Add to Home Screen\"",
+      "confirm": "Confirm with \"Add\""
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -798,5 +798,17 @@
     "tempo": "Tempo",
     "endurance": "Endurance",
     "recovery": "Récup."
+  },
+  "install": {
+    "title": "Ajouter OpenStride à votre écran d'accueil",
+    "subtitle": "S'ouvre instantanément, fonctionne hors ligne, et garde sa place sur votre téléphone.",
+    "action": "Installer",
+    "later": "Plus tard",
+    "ios": {
+      "subtitle": "Installez avant de connecter une source : sur iPhone, une app installée garde ses propres données — ce qui serait importé dans Safari resterait derrière.",
+      "share": "Touchez Partager dans la barre Safari",
+      "addToHome": "Choisissez « Sur l'écran d'accueil »",
+      "confirm": "Confirmez avec « Ajouter »"
+    }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import router from './router'
 import { IndexedDBService } from './services/IndexedDBService'
 import { aggregationService } from '@/services/AggregationService'
 import { getPWAUpdateService } from '@/services/PWAUpdateService'
+import { getInstallService } from '@/services/InstallService'
 import { getPublicDataListener } from '@/services/PublicDataListener'
 import { getMigrationService } from '@/services/MigrationService'
 import { getSyncService } from '@/services/SyncService'
@@ -83,6 +84,10 @@ async function bootstrap() {
   // 4. Initialize PWA update service
   const pwaUpdateService = getPWAUpdateService()
   await pwaUpdateService.initialize()
+
+  // 4 bis. Catch `beforeinstallprompt` before anything renders — Chromium fires
+  // it once during load, and without a listener already in place it is lost.
+  await getInstallService().initialize()
 
   // 5. Register plugin routes
   const { allAppPlugins } = await import('@/services/ExtensionPluginRegistry')

--- a/src/services/InstallService.ts
+++ b/src/services/InstallService.ts
@@ -1,0 +1,210 @@
+import { IndexedDBService } from './IndexedDBService'
+
+/**
+ * Where the user is, from the point of view of installing the app.
+ *
+ * The distinction that matters is not the OS but who owns the install gesture:
+ * Chromium hands us the prompt and we can trigger it, Safari never does and the
+ * user has to go through the share sheet themselves.
+ */
+export type InstallPlatform =
+  | 'installed' // already running from the home screen
+  | 'android-chromium' // we can call prompt()
+  | 'ios-safari' // guide only, no API
+  | 'desktop'
+  | 'unsupported'
+
+/** Persisted in `settings`, and only ever read to decide whether to ask again. */
+export interface InstallPromptState {
+  /** Distinct days the site was opened — not reloads, which say nothing. */
+  visitDays: number
+  /** ISO day of the last counted visit, so one session counts once. */
+  lastVisitDay: string
+  dismissedAt: number | null
+  dismissCount: number
+}
+
+const STORAGE_KEY = 'install_prompt_state'
+
+/** Two refusals is an answer; a third invitation is nagging. */
+const MAX_DISMISSALS = 2
+
+/** Android waits for the habit to show. iOS cannot afford to wait — see below. */
+export const ANDROID_MIN_VISIT_DAYS = 4
+
+const EMPTY_STATE: InstallPromptState = {
+  visitDays: 0,
+  lastVisitDay: '',
+  dismissedAt: null,
+  dismissCount: 0
+}
+
+const today = (): string => new Date().toISOString().slice(0, 10)
+
+/**
+ * The `beforeinstallprompt` event, held for later.
+ *
+ * Chromium fires it once, during load, long before the user reaches the moment
+ * worth asking at. Without `preventDefault()` and a reference kept here, it is
+ * gone and `prompt()` can never be called. This is the whole reason the service
+ * has to be initialised at bootstrap rather than by a component.
+ */
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+export class InstallService {
+  private static instance: InstallService | null = null
+
+  private deferredPrompt: BeforeInstallPromptEvent | null = null
+  private state: InstallPromptState = { ...EMPTY_STATE }
+  public emitter = new EventTarget()
+
+  private constructor() {
+    /* singleton */
+  }
+
+  public static getInstance(): InstallService {
+    if (!InstallService.instance) InstallService.instance = new InstallService()
+    return InstallService.instance
+  }
+
+  /** Call once, at bootstrap, before anything renders. */
+  public async initialize(): Promise<void> {
+    window.addEventListener('beforeinstallprompt', evt => {
+      evt.preventDefault()
+      this.deferredPrompt = evt as BeforeInstallPromptEvent
+      this.emitter.dispatchEvent(new Event('availability-changed'))
+    })
+
+    window.addEventListener('appinstalled', () => {
+      this.deferredPrompt = null
+      this.emitter.dispatchEvent(new Event('availability-changed'))
+    })
+
+    await this.loadState()
+    await this.countVisit()
+  }
+
+  // ── Platform ───────────────────────────────────────────────────────────────
+
+  public isStandalone(): boolean {
+    const displayMode = window.matchMedia?.('(display-mode: standalone)').matches ?? false
+    // iOS predates the display-mode media query and uses its own flag.
+    const iosStandalone = (window.navigator as { standalone?: boolean }).standalone === true
+    return displayMode || iosStandalone
+  }
+
+  public get platform(): InstallPlatform {
+    if (this.isStandalone()) return 'installed'
+
+    const ua = navigator.userAgent
+    // iPadOS 13+ reports itself as a Mac; the touch points give it away.
+    const isIOS =
+      /iPad|iPhone|iPod/.test(ua) ||
+      (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+
+    if (isIOS) {
+      // Only Safari can add to the home screen. Chrome and Firefox on iOS are
+      // Safari underneath but do not offer it, so guiding them would be a lie.
+      const isSafari = !/CriOS|FxiOS|EdgiOS|OPiOS/.test(ua)
+      return isSafari ? 'ios-safari' : 'unsupported'
+    }
+
+    if (/Android/.test(ua)) return this.deferredPrompt ? 'android-chromium' : 'unsupported'
+
+    return 'desktop'
+  }
+
+  /** True when there is a real install gesture to offer on this device. */
+  public get canInstall(): boolean {
+    const platform = this.platform
+    return platform === 'android-chromium' || platform === 'ios-safari'
+  }
+
+  /** True only where we own the gesture — Android. Elsewhere we can only guide. */
+  public get canPrompt(): boolean {
+    return this.deferredPrompt !== null
+  }
+
+  // ── Asking ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Show the browser's own install dialog.
+   *
+   * Resolves to what the user chose, or `unavailable` when there was no stored
+   * event — on iOS, and on any Chromium that judged the app not installable.
+   */
+  public async promptInstall(): Promise<'accepted' | 'dismissed' | 'unavailable'> {
+    const evt = this.deferredPrompt
+    if (!evt) return 'unavailable'
+
+    // The event is single-use: Chromium refuses a second prompt() on it.
+    this.deferredPrompt = null
+    await evt.prompt()
+    const { outcome } = await evt.userChoice
+    if (outcome === 'dismissed') await this.recordDismissal()
+    this.emitter.dispatchEvent(new Event('availability-changed'))
+    return outcome
+  }
+
+  // ── State ──────────────────────────────────────────────────────────────────
+
+  public getState(): InstallPromptState {
+    return { ...this.state }
+  }
+
+  /** False once the user has said no often enough to mean it. */
+  public get mayAsk(): boolean {
+    return this.state.dismissCount < MAX_DISMISSALS
+  }
+
+  public get visitDays(): number {
+    return this.state.visitDays
+  }
+
+  public async recordDismissal(): Promise<void> {
+    this.state.dismissedAt = Date.now()
+    this.state.dismissCount += 1
+    await this.saveState()
+    this.emitter.dispatchEvent(new Event('availability-changed'))
+  }
+
+  private async loadState(): Promise<void> {
+    try {
+      const db = await IndexedDBService.getInstance()
+      const saved = await db.getData<InstallPromptState>(STORAGE_KEY)
+      if (saved) this.state = { ...EMPTY_STATE, ...saved }
+    } catch {
+      // IndexedDB may be unavailable (private mode, tests) — defaults stand.
+    }
+  }
+
+  private async saveState(): Promise<void> {
+    try {
+      const db = await IndexedDBService.getInstance()
+      await db.saveData(STORAGE_KEY, { ...this.state })
+    } catch {
+      // Losing this only costs an extra invitation, never data.
+    }
+  }
+
+  /**
+   * Count one visit per calendar day.
+   *
+   * Reloads and tab switches within a day say nothing about habit; coming back
+   * on four different days does.
+   */
+  private async countVisit(): Promise<void> {
+    const day = today()
+    if (this.state.lastVisitDay === day) return
+    this.state.lastVisitDay = day
+    this.state.visitDays += 1
+    await this.saveState()
+  }
+}
+
+export function getInstallService(): InstallService {
+  return InstallService.getInstance()
+}

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -18,6 +18,9 @@
       </div>
     </div>
 
+    <!-- Android only, and only once the app has proven useful -->
+    <InstallPrompt variant="banner" />
+
     <!-- Activities Feed -->
     <div ref="scrollArea" class="feed-container">
       <ActivityCard
@@ -59,6 +62,7 @@ import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import ActivityCard from '@/components/ActivityCard.vue'
+import InstallPrompt from '@/components/InstallPrompt.vue'
 import { useMixedFeed } from '@/composables/useMixedFeed'
 import { useFeedMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import { debounce } from '@/utils/debounce'

--- a/src/views/onboarding/OnboardingProviderStep.vue
+++ b/src/views/onboarding/OnboardingProviderStep.vue
@@ -5,6 +5,10 @@
       {{ t('onboarding.provider.subtitle') }}
     </p>
 
+    <!-- iOS only: installing after connecting a provider would strand the
+         import in Safari's storage, so the invitation comes first. -->
+    <InstallPrompt variant="gate" class="mb-6" />
+
     <!-- Liste de sélection (si aucun provider sélectionné) -->
     <div v-if="!selectedProviderId">
       <ul class="space-y-4">
@@ -60,6 +64,7 @@
 </template>
 
 <script setup lang="ts">
+import InstallPrompt from '@/components/InstallPrompt.vue'
 import { ref, watch, shallowRef, onMounted, onUnmounted, type Component as VueComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { installableProviderPlugins } from '@/services/ProviderPluginRegistry'

--- a/tests/unit/InstallService.spec.ts
+++ b/tests/unit/InstallService.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  store: new Map<string, unknown>(),
+  getInstance: vi.fn()
+}))
+
+vi.mock('@/services/IndexedDBService', () => ({
+  IndexedDBService: {
+    getInstance: async () => ({
+      getData: async (key: string) => mocks.store.get(key),
+      saveData: async (key: string, value: unknown) => {
+        mocks.store.set(key, value)
+      }
+    })
+  }
+}))
+
+const { InstallService } = await import('@/services/InstallService')
+
+const IOS_SAFARI =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1'
+const IOS_CHROME = IOS_SAFARI.replace('Version/17.4', 'CriOS/122.0')
+const ANDROID_CHROME =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0 Mobile Safari/537.36'
+
+function setEnvironment(ua: string, standalone = false, maxTouchPoints = 5) {
+  Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true })
+  Object.defineProperty(navigator, 'maxTouchPoints', { value: maxTouchPoints, configurable: true })
+  Object.defineProperty(window.navigator, 'standalone', { value: false, configurable: true })
+  window.matchMedia = ((query: string) => ({
+    matches: standalone && query.includes('standalone'),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  })) as unknown as typeof window.matchMedia
+}
+
+/** A stand-in for the Chromium event, which happy-dom does not fire. */
+function fireBeforeInstallPrompt(outcome: 'accepted' | 'dismissed' = 'accepted') {
+  const evt = new Event('beforeinstallprompt') as Event & {
+    prompt: () => Promise<void>
+    userChoice: Promise<{ outcome: string }>
+  }
+  evt.prompt = vi.fn(async () => {})
+  evt.userChoice = Promise.resolve({ outcome })
+  window.dispatchEvent(evt)
+  return evt
+}
+
+/** Each test needs a service that has not already counted today's visit. */
+async function freshService() {
+  ;(InstallService as unknown as { instance: unknown }).instance = null
+  const service = InstallService.getInstance()
+  await service.initialize()
+  return service
+}
+
+describe('InstallService — reading the platform', () => {
+  beforeEach(() => {
+    mocks.store.clear()
+    vi.clearAllMocks()
+  })
+
+  it('recognises an installable Android only once the browser has offered', async () => {
+    setEnvironment(ANDROID_CHROME)
+    const service = await freshService()
+
+    // Chromium decides whether the app qualifies; before its event there is
+    // nothing to trigger, so claiming otherwise would show a dead button.
+    expect(service.platform).toBe('unsupported')
+    expect(service.canPrompt).toBe(false)
+
+    fireBeforeInstallPrompt()
+    expect(service.platform).toBe('android-chromium')
+    expect(service.canPrompt).toBe(true)
+  })
+
+  it('recognises Safari on iOS, which never offers an event', async () => {
+    setEnvironment(IOS_SAFARI)
+    const service = await freshService()
+
+    expect(service.platform).toBe('ios-safari')
+    expect(service.canInstall).toBe(true)
+    // There is no API: the UI can only show where the gesture lives.
+    expect(service.canPrompt).toBe(false)
+  })
+
+  it('does not guide Chrome on iOS, which cannot add to the home screen', async () => {
+    setEnvironment(IOS_CHROME)
+    const service = await freshService()
+
+    expect(service.platform).toBe('unsupported')
+    expect(service.canInstall).toBe(false)
+  })
+
+  it('sees an iPad that reports itself as a Mac', async () => {
+    // iPadOS 13+ sends a desktop UA; the touch points are what give it away.
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
+    setEnvironment('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Safari/605.1.15', false, 5)
+    const service = await freshService()
+
+    expect(service.platform).toBe('ios-safari')
+  })
+
+  it('says nothing to a user already running the installed app', async () => {
+    setEnvironment(ANDROID_CHROME, true)
+    const service = await freshService()
+    fireBeforeInstallPrompt()
+
+    expect(service.platform).toBe('installed')
+    expect(service.canInstall).toBe(false)
+  })
+})
+
+describe('InstallService — holding the browser event', () => {
+  beforeEach(() => {
+    mocks.store.clear()
+    vi.clearAllMocks()
+    setEnvironment(ANDROID_CHROME)
+  })
+
+  it('keeps the event so it can be used long after the page loaded', async () => {
+    const service = await freshService()
+    const evt = fireBeforeInstallPrompt('accepted')
+
+    // The event fires during load; the invitation comes much later. Without
+    // preventDefault and this reference, prompt() could never be called.
+    expect(await service.promptInstall()).toBe('accepted')
+    expect(evt.prompt).toHaveBeenCalledOnce()
+  })
+
+  it('reports unavailable rather than throwing when there is no event', async () => {
+    const service = await freshService()
+    expect(await service.promptInstall()).toBe('unavailable')
+  })
+
+  it('does not reuse a spent event, which Chromium refuses', async () => {
+    const service = await freshService()
+    fireBeforeInstallPrompt('accepted')
+
+    await service.promptInstall()
+    expect(await service.promptInstall()).toBe('unavailable')
+  })
+
+  it('counts a refused browser dialog as a refusal', async () => {
+    const service = await freshService()
+    fireBeforeInstallPrompt('dismissed')
+
+    expect(await service.promptInstall()).toBe('dismissed')
+    expect(service.getState().dismissCount).toBe(1)
+  })
+
+  it('forgets the event once the app is installed', async () => {
+    const service = await freshService()
+    fireBeforeInstallPrompt()
+    expect(service.canPrompt).toBe(true)
+
+    window.dispatchEvent(new Event('appinstalled'))
+    expect(service.canPrompt).toBe(false)
+  })
+})
+
+describe('InstallService — knowing when to stop asking', () => {
+  beforeEach(() => {
+    mocks.store.clear()
+    vi.clearAllMocks()
+    setEnvironment(ANDROID_CHROME)
+  })
+
+  it('stops after two refusals', async () => {
+    const service = await freshService()
+    expect(service.mayAsk).toBe(true)
+
+    await service.recordDismissal()
+    expect(service.mayAsk).toBe(true)
+
+    await service.recordDismissal()
+    // Two noes is an answer; a third invitation is nagging.
+    expect(service.mayAsk).toBe(false)
+  })
+
+  it('remembers refusals across reloads', async () => {
+    const first = await freshService()
+    await first.recordDismissal()
+    await first.recordDismissal()
+
+    const second = await freshService()
+    expect(second.mayAsk).toBe(false)
+  })
+})
+
+describe('InstallService — counting visits', () => {
+  beforeEach(() => {
+    mocks.store.clear()
+    vi.clearAllMocks()
+    setEnvironment(ANDROID_CHROME)
+  })
+
+  it('counts the first visit', async () => {
+    const service = await freshService()
+    expect(service.visitDays).toBe(1)
+  })
+
+  it('counts one visit per day, not per reload', async () => {
+    // Four reloads in one sitting say nothing about habit.
+    await freshService()
+    await freshService()
+    const third = await freshService()
+
+    expect(third.visitDays).toBe(1)
+  })
+
+  it('counts a genuine return on another day', async () => {
+    const first = await freshService()
+    expect(first.visitDays).toBe(1)
+
+    const state = mocks.store.get('install_prompt_state') as { lastVisitDay: string }
+    mocks.store.set('install_prompt_state', { ...state, lastVisitDay: '2020-01-01' })
+
+    const second = await freshService()
+    expect(second.visitDays).toBe(2)
+  })
+})

--- a/tests/unit/useInstallPrompt.spec.ts
+++ b/tests/unit/useInstallPrompt.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+
+const mocks = vi.hoisted(() => ({
+  platform: 'ios-safari' as string,
+  canInstall: true,
+  mayAsk: true,
+  visitDays: 1,
+  providers: [] as unknown[],
+  storages: [] as unknown[],
+  activities: [] as { deleted?: boolean }[]
+}))
+
+vi.mock('@/services/InstallService', () => ({
+  ANDROID_MIN_VISIT_DAYS: 4,
+  getInstallService: () => ({
+    get platform() {
+      return mocks.platform
+    },
+    get canInstall() {
+      return mocks.canInstall
+    },
+    get canPrompt() {
+      return mocks.platform === 'android-chromium'
+    },
+    get mayAsk() {
+      return mocks.mayAsk
+    },
+    get visitDays() {
+      return mocks.visitDays
+    },
+    emitter: new EventTarget(),
+    promptInstall: vi.fn(),
+    recordDismissal: vi.fn()
+  })
+}))
+
+vi.mock('@/services/DataProviderPluginManager', () => ({
+  DataProviderPluginManager: {
+    getInstance: () => ({ getEnabledPlugins: async () => mocks.providers })
+  }
+}))
+vi.mock('@/services/StoragePluginManager', () => ({
+  StoragePluginManager: {
+    getInstance: () => ({ getEnabledPlugins: async () => mocks.storages })
+  }
+}))
+vi.mock('@/services/ActivityService', () => ({
+  getActivityService: async () => ({ getAllActivities: async () => mocks.activities })
+}))
+
+const { useInstallPrompt } = await import('@/composables/useInstallPrompt')
+
+/** The composable uses onMounted, so it needs a host component. */
+async function harness() {
+  let api!: ReturnType<typeof useInstallPrompt>
+  mount(
+    defineComponent({
+      setup() {
+        api = useInstallPrompt()
+        return () => h('div')
+      }
+    })
+  )
+  await flushPromises()
+  return api
+}
+
+function reset(over: Partial<typeof mocks> = {}) {
+  Object.assign(mocks, {
+    platform: 'ios-safari',
+    canInstall: true,
+    mayAsk: true,
+    visitDays: 1,
+    providers: [],
+    storages: [],
+    activities: []
+  })
+  Object.assign(mocks, over)
+}
+
+describe('useInstallPrompt — iOS asks before anything is connected', () => {
+  beforeEach(() => reset())
+
+  it('invites while nothing is connected yet', async () => {
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(true)
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+
+  it('stays quiet once a provider is connected', async () => {
+    // Too late to be useful: installing now would strand the import in Safari's
+    // own storage, which the home-screen app does not share.
+    reset({ providers: [{ id: 'garmin' }] })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(false)
+  })
+
+  it('stays quiet once a storage is connected', async () => {
+    reset({ storages: [{ id: 'gdrive' }] })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(false)
+  })
+
+  it('does not wait for visits — the window closes as soon as data arrives', async () => {
+    reset({ visitDays: 1 })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(true)
+  })
+})
+
+describe('useInstallPrompt — Android waits for the habit', () => {
+  beforeEach(() => reset({ platform: 'android-chromium' }))
+
+  it('says nothing before enough distinct days', async () => {
+    reset({ platform: 'android-chromium', visitDays: 3, activities: [{}] })
+    const api = await harness()
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+
+  it('says nothing while there is no imported activity', async () => {
+    reset({ platform: 'android-chromium', visitDays: 9, activities: [] })
+    const api = await harness()
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+
+  it('invites once the app has proven useful', async () => {
+    reset({ platform: 'android-chromium', visitDays: 4, activities: [{}] })
+    const api = await harness()
+    expect(api.offerAfterEngagement.value).toBe(true)
+    // The iOS urgency does not apply: installed and browser share one storage.
+    expect(api.offerBeforePlugins.value).toBe(false)
+  })
+
+  it('ignores deleted activities, which are not a reason to install', async () => {
+    reset({ platform: 'android-chromium', visitDays: 9, activities: [{ deleted: true }] })
+    const api = await harness()
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+})
+
+describe('useInstallPrompt — when not to ask at all', () => {
+  beforeEach(() => reset())
+
+  it('never asks a user already running the installed app', async () => {
+    reset({ platform: 'installed', canInstall: false })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(false)
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+
+  it('never asks on desktop', async () => {
+    reset({ platform: 'desktop', canInstall: false })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(false)
+    expect(api.offerAfterEngagement.value).toBe(false)
+  })
+
+  it('stops once the user has refused enough times', async () => {
+    reset({ mayAsk: false })
+    const api = await harness()
+    expect(api.offerBeforePlugins.value).toBe(false)
+  })
+})


### PR DESCRIPTION
Rien ne proposait l'installation. Le manifeste rendait l'app installable, mais aucun code ne capturait `beforeinstallprompt` — l'invitation ne venait donc que du menu du navigateur, quand elle venait.

## La contrainte qui commande le design

Le moment ne peut pas être le même sur les deux plateformes, et la raison est le stockage, pas le goût.

**Sur iOS, une app ajoutée à l'écran d'accueil a son propre conteneur.** Rien n'est copié depuis Safari. Un athlète qui connecte Garmin dans le navigateur, importe sa saison, puis installe — **ouvre une app vide**.

Sur Android, navigateur et app installée partagent un seul stockage. Rien n'est perdu à attendre.

## La règle

| Plateforme | Quand | Où |
| --- | --- | --- |
| **iOS Safari** | **avant** tout branchement de plugin | étape provider de l'onboarding + onglet sources de données |
| **Android Chromium** | après engagement : ≥ 4 jours distincts **et** ≥ 1 activité importée | bandeau rejetable sur le feed |
| Chrome / Firefox iOS | jamais | ils ne savent pas ajouter à l'écran d'accueil |
| Desktop, déjà installé | jamais | rien à proposer |

## Détails qui comptent

- **`InstallService` est initialisé dans `main.ts` avant le montage de l'app.** Chromium ne déclenche `beforeinstallprompt` **qu'une fois, pendant le chargement**, bien avant le moment où il vaut la peine de demander. Sans écouteur déjà en place et une référence gardée, `prompt()` ne pourra plus jamais être appelé. Ne pas déplacer dans un composant.
- **iOS n'expose aucune API d'installation.** Cette variante montre donc où se trouve le geste (Partager → Sur l'écran d'accueil) au lieu d'un bouton mort.
- **Les visites sont comptées par jour distinct**, pas par chargement : quatre rechargements dans la même session ne disent rien d'une habitude.
- **Deux refus et on arrête.** `install_prompt_state` est de l'état applicatif qui pilote cette décision, pas de la télémétrie — l'app n'en a pas, et un compteur purement local ne pourrait de toute façon rien agréger.

## Pas de lien vers les stores

Il n'y a pas encore d'app native, et un lien vers une fiche vide est pire que pas de lien. Le jour où une app Capacitor existe, HealthKit et Health Connect entrent tels quels dans le contrat `ProviderPlugin` — un dossier par plateforme dans `plugins/data-providers/`, sans toucher au core.

## Vérifications

- `tsc --noEmit`, ESLint, Prettier et build propres ; **660 tests** verts (+26)
- Vérifié dans un vrai navigateur sur les cinq cas :

```
iOS vierge                    prompt:oui  bouton:non  guide:oui
iOS avec Garmin déjà branché  prompt:non  bouton:non  guide:non
Android sans engagement       prompt:non  bouton:non  guide:non
Android engagé                prompt:oui  bouton:oui  guide:non
Desktop                       prompt:non  bouton:non  guide:non
```

- Documenté : `docs/INSTALL_FUNNEL.md` (la règle, le piège de l'événement unique, pourquoi l'asymétrie), référencé depuis `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH


---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_