### PR TITLE
fix(progress): réconcilier une config stockée au lieu de seulement la compléter

### DIFF
--- a/plugins/app-extensions/AggregatedProgress/AggregatedProgressWidget.vue
+++ b/plugins/app-extensions/AggregatedProgress/AggregatedProgressWidget.vue
@@ -194,34 +194,63 @@ const periodLabel = (key: string, period: Period): string => {
 
 // ── Loading ─────────────────────────────────────────────────────────────────
 
-/** Register the metrics this widget needs, the first time it is shown. */
-async function ensureMetricsExist() {
+/**
+ * Bring the stored definitions in line with what this widget expects.
+ *
+ * Reconciled every time, not merely completed when absent. Only adding the
+ * missing ids left a config written by an older version frozen in its old
+ * shape: it still carried `displayUnit`/`displayFactor` and no `dimension`, so
+ * a distance rendered as raw metres — and because nothing "changed", the
+ * aggregates were never rebuilt either, leaving the whole widget on zeroes.
+ *
+ * `enabled` is the one field a user can own, so it is preserved.
+ */
+async function reconcileMetrics(): Promise<boolean> {
   const metrics = aggregationCtx.listMetrics()
   let changed = false
 
   for (const base of BASE_METRICS) {
     for (const period of PERIODS) {
       const id = `${period}_${base.id}`
-      if (metrics.find(m => m.id === id)) continue
-      metrics.push({
-        id,
-        label: base.id,
-        enabled: true,
+      const expected = {
         sourceRef: base.sourceRef,
-        aggregation: 'sum',
+        aggregation: 'sum' as const,
         periods: [period],
         unit: base.unit,
         decimals: base.decimals,
         dimension: 'dimension' in base ? base.dimension : undefined
-      })
+      }
+      const existing = metrics.find(m => m.id === id)
+
+      if (!existing) {
+        metrics.push({ id, label: base.id, enabled: true, ...expected })
+        changed = true
+        continue
+      }
+
+      // Fields this widget owns; anything else the user set is left alone.
+      const stale =
+        existing.sourceRef !== expected.sourceRef ||
+        existing.unit !== expected.unit ||
+        existing.decimals !== expected.decimals ||
+        existing.dimension !== expected.dimension ||
+        'displayFactor' in existing ||
+        'displayUnit' in existing
+
+      if (!stale) continue
+
+      Object.assign(existing, expected)
+      // Drop what the type no longer knows about, so the shape converges.
+      delete (existing as Record<string, unknown>).displayFactor
+      delete (existing as Record<string, unknown>).displayUnit
       changed = true
     }
   }
-  if (!changed) return
+  if (!changed) return false
 
   await storage.saveData('aggregationConfig', { metrics })
   await aggregationCtx.loadConfigFromSettings()
-  await rebuildFromScratch()
+  return true
 }
 
 async function rebuildFromScratch() {
@@ -235,7 +264,8 @@ async function rebuildFromScratch() {
   await aggregationCtx.rebuildAll(activities as Record<string, unknown>[], detailsMap)
 }
 
-async function loadMetrics() {
+/** True when the store holds no aggregate at all for the current definitions. */
+async function loadMetrics(): Promise<{ empty: boolean }> {
   const enabled = aggregationCtx.listMetrics().filter(m => m.enabled)
   availablePeriods.value = PERIODS.filter(p => enabled.some(m => m.periods.includes(p)))
 
@@ -258,13 +288,30 @@ async function loadMetrics() {
   const points = selected ? selected.records.slice(-CHART_POINTS) : []
   chartLabels.value = points.map(r => periodLabel(r.periodKey, selectedPeriod.value))
   chartSI.value = points.map(r => r.value)
+
+  return { empty: series.every(s => s.records.length === 0) }
 }
 
-watch([selectedPeriod, selectedMetric], loadMetrics)
+watch([selectedPeriod, selectedMetric], () => {
+  void loadMetrics()
+})
 
 onMounted(async () => {
-  await ensureMetricsExist()
-  await loadMetrics()
+  const reconciled = await reconcileMetrics()
+  if (reconciled) await rebuildFromScratch()
+
+  const { empty } = await loadMetrics()
+  // A definition can exist with no aggregate behind it — the aggregation is
+  // event-driven, so activities imported before the metric was registered were
+  // never counted. Rebuilding once here is what turns a widget of zeroes into
+  // a widget of figures; `rebuildAll` purges first, so it cannot double-count.
+  if (empty) {
+    const activities = await storage.exportDB('activities')
+    if (activities.length > 0) {
+      await rebuildFromScratch()
+      await loadMetrics()
+    }
+  }
 })
 
 const onRefresh = async () => {


### PR DESCRIPTION
Le widget refait dans la #75 affiche toujours des zéros et des mètres à quiconque l'utilisait déjà — c'est-à-dire à peu près tous ceux qui l'avaient activé. Deux causes, la même ligne :

```ts
if (metrics.find(m => m.id === id)) continue
```

**1. Les unités.** Une config écrite par une version antérieure garde sa forme pour toujours. Elle porte `displayUnit`/`displayFactor` et **pas** `dimension`, donc `displayOf` retombe sur la branche brute : une distance s'affiche `0.0m` au lieu de `30.0km`.

**2. Les zéros.** Comme rien n'avait « changé », les agrégats n'étaient jamais reconstruits. Les chiffres étaient donc à zéro *en plus* d'être mal convertis.

## Ce qui change

Les définitions que ce widget possède sont **réconciliées à chaque montage**, plus seulement complétées quand elles manquent : un `sourceRef`, `unit`, `decimals` ou `dimension` périmé est réécrit, et les deux champs que le type ne connaît plus sont supprimés pour que la forme stockée converge. `enabled` est le seul champ qu'un utilisateur peut posséder, il survit.

Une définition peut aussi exister sans aucun agrégat derrière : l'agrégation est event-driven, donc les activités importées avant l'enregistrement d'une métrique n'ont jamais été comptées. Quand le store ne contient **rien** pour les définitions courantes et qu'il y a des activités, il reconstruit une fois. `rebuildAll` purge avant de reconstruire (`AggregationService.ts:245`), donc pas de double comptage.

## Vérifications

Reproduit puis corrigé en navigateur avec une config héritée, exactement celle qu'un utilisateur existant a encore sur disque :

```
avant   DISTANCE 0.0m    DURÉE 0.0h   D+ CUMULÉ 0m
après   DISTANCE 30.0km  DURÉE 2.3h   D+ CUMULÉ 360m
week_distance stocké : dimension="distance", displayFactor supprimé
```

Les deux systèmes d'unités revérifiés :

```
métrique   DISTANCE 33.0km   D+ CUMULÉ 360m
impérial   DISTANCE 20.5mi   D+ CUMULÉ 1181ft
```

**665 tests** verts, `tsc`, ESLint, Prettier propres.

> À noter : au moment où tu as regardé, le déploiement de la #75 n'était pas encore passé — aucun tag ne la contenait. Donc deux raisons se cumulaient, le délai et ce bug-ci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH


---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_