### PR TITLE
ci(release): pousser la branche avant le tag, et réessayer si main a bougé

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -47,23 +47,59 @@ jobs:
             }
             core.setOutput('bump_type', bumpType);
 
-      - name: Bump version
+      # Bump, commit, push the branch, and only then the tag.
+      #
+      # `git push origin main --tags` used to do all of it at once, from a
+      # checkout taken when the run started. Two merges 18 s apart was enough:
+      # the second landed while the first run was still working, the tag pushed
+      # fine and the branch was rejected as non-fast-forward. That left v0.5.34
+      # tagged but not on main, package.json still on 0.5.33, and every later run
+      # dying on "tag already exists" — four merges shipped nothing.
+      #
+      # `concurrency` above serialises runs; it cannot make a running job's
+      # checkout current. Hence the rebase-and-retry here.
+      - name: Bump, commit and tag
         id: bump
-        run: |
-          OLD=$(node -p "require('./package.json').version")
-          npm version ${{ steps.bump-type.outputs.bump_type }} --no-git-tag-version
-          NEW=$(node -p "require('./package.json').version")
-          echo "new_version=${NEW}" >> $GITHUB_OUTPUT
-          echo "Bumped: ${OLD} -> ${NEW}"
-
-      - name: Commit and tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json
-          git commit -m "chore(release): v${{ steps.bump.outputs.new_version }}"
-          git tag "v${{ steps.bump.outputs.new_version }}"
-          git push origin main --tags
+
+          for attempt in 1 2 3 4 5; do
+            # Whatever landed while this run was working comes first.
+            git fetch --quiet origin main --tags
+            git reset --quiet --hard origin/main
+
+            OLD=$(node -p "require('./package.json').version")
+            npm version "${{ steps.bump-type.outputs.bump_type }}" --no-git-tag-version >/dev/null
+            NEW=$(node -p "require('./package.json').version")
+
+            # A tag can already exist from an earlier run that got this far and
+            # then failed to push the branch. Take the next free number rather
+            # than stopping the release train on it.
+            while git rev-parse -q --verify "refs/tags/v${NEW}" >/dev/null; do
+              echo "v${NEW} is already tagged, taking the next one"
+              npm version patch --no-git-tag-version >/dev/null
+              NEW=$(node -p "require('./package.json').version")
+            done
+
+            git add package.json package-lock.json
+            git commit --quiet -m "chore(release): v${NEW}"
+
+            # The branch first: a tag naming a commit that is not on main is
+            # worse than no tag, and is exactly what happened before.
+            if git push --quiet origin main; then
+              git tag "v${NEW}"
+              git push --quiet origin "refs/tags/v${NEW}"
+              echo "new_version=${NEW}" >> $GITHUB_OUTPUT
+              echo "Released: ${OLD} -> ${NEW}"
+              exit 0
+            fi
+
+            echo "main moved while this run was working, retrying (${attempt}/5)"
+          done
+
+          echo "::error::could not push the release commit after 5 attempts"
+          exit 1
 
   deploy:
     name: Deploy to Firebase Hosting & Functions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,12 @@ Services emit events via `EventTarget`, UI components listen and react. Business
 - Le workflow commit `chore(release): vX.Y.Z`, crée le tag, et déploie en prod
 - `deploy-production.yml` reste dispo en `workflow_dispatch` pour redeploy manuel sans bump
 - **Ne JAMAIS** modifier `version` dans `package.json`, créer de commits `chore: bump version`, ou créer de tags `v*` manuellement
+- **Laisser le déploiement finir avant de merger la PR suivante.** Le workflow
+  rebase et réessaie désormais, mais deux merges à quelques secondes d'écart ont
+  déjà cassé la chaîne : le run partait d'un `main` devenu obsolète, poussait le
+  tag et se faisait rejeter la branche. Résultat, un tag orphelin, un
+  `package.json` jamais bumpé, et **quatre merges livrés nulle part**. Vérifier
+  qu'un tag `vX.Y.Z` est apparu avant d'enchaîner.
 
 ### Common Pitfalls
 


### PR DESCRIPTION
**Quatre merges n'ont rien livré.** `package.json` est resté sur 0.5.33, un tag `v0.5.34` existe en pointant sur un commit qui n'a jamais atteint `main`, et chaque exécution suivante meurt sur `fatal: tag 'v0.5.34' already exists`.

## Ce qui s'est passé

Le déclencheur est de moi : j'ai mergé deux PR à **18 secondes** d'écart, puis deux autres à **25 secondes**. Le premier run avait déjà fait son checkout quand le merge suivant a atterri :

```
* [new tag]  v0.5.34 -> v0.5.34             ← le tag est parti
! [rejected] main -> main (fetch first)     ← la branche non
```

`git push origin main --tags` pousse les deux d'un coup, et une branche rejetée laisse le tag derrière elle.

**Correction de mon premier diagnostic** : `concurrency` était déjà configuré et faisait son travail. Il met les runs en file, mais il ne rend pas *courant* le checkout d'un job déjà démarré. C'est là que j'avais tort.

## Trois changements

1. **`fetch` + `reset` sur `origin/main` avant de commiter, avec cinq tentatives.** Un merge qui atterrit en cours de run coûte une boucle, plus la release.
2. **La branche d'abord, le tag seulement si elle est passée.** Un tag qui nomme un commit absent de `main` est pire que pas de tag — c'est précisément ce qui s'est produit.
3. **Prendre le numéro libre suivant** quand un tag existe déjà, au lieu d'arrêter le train dessus.

Le point 3 est aussi **ce qui débloque l'état actuel** : je ne peux pas supprimer le `v0.5.34` orphelin depuis cet environnement — le proxy git refuse la suppression de ref et l'API répond **403** avec le token de session. Le workflow l'enjambe donc.

## Effet du merge de cette PR

Le prochain push sur `main` publiera **v0.5.35** et déploiera tout ce qui a été mergé depuis v0.5.33 : les PR #74, #75, #76 et #77.

## Vérification

La boucle a été exécutée contre une reproduction de l'état bloquant :

```
tags avant : v0.5.34
  v0.5.34 déjà pris, on prend le suivant
résultat : 0.5.33 -> 0.5.35
```

YAML validé, Prettier propre.

## Note pratique

`CLAUDE.md` demande maintenant de **laisser un déploiement finir avant de merger la PR suivante**, et de vérifier qu'un tag est apparu. Le workflow le tolère désormais, mais le train de release n'est pas l'endroit où le découvrir.

Le tag orphelin `v0.5.34` reste dans le dépôt, inoffensif. Deux clics dans l'interface GitHub si tu veux le nettoyer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH


---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_