### PR TITLE
feat(landing): expliquer OpenStride à quelqu'un qui arrive

### DIFF
--- a/src/assets/styles/appheader.css
+++ b/src/assets/styles/appheader.css
@@ -36,10 +36,6 @@
   animation-timeline: scroll();
 }
 
-.header h1 {
-  margin: 10px;
-}
-
 .logo * {
   cursor: pointer;
 }
@@ -55,6 +51,8 @@
 }
 
 .brand-name {
+  /* Carried over from the `.header h1` rule this used to inherit */
+  margin: 10px;
   font-family: var(--font-main);
   font-size: var(--font-size-logo);
   font-weight: var(--font-weight-bold);

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -9,9 +9,13 @@
       tabindex="0"
     >
       <img src="@/assets/logo.svg" :alt="t('app.logo')" />
-      <h1 class="brand-name">
+      <!-- A span, not an h1: this is a logo inside a button that navigates
+           home, not the heading of the document underneath it. As an h1 it
+           competed with every page's real title, and the landing page ended up
+           with two. -->
+      <span class="brand-name">
         <span class="normal">open</span><span class="secondary">Stride</span>
-      </h1>
+      </span>
     </div>
 
     <div class="header-actions">

--- a/src/components/SetupAlertBanner.vue
+++ b/src/components/SetupAlertBanner.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="setup-banner">
-    <div v-if="bannerType" class="setup-banner">
+    <div v-if="bannerType && !onOwnCallToAction" class="setup-banner">
       <div class="setup-banner-content">
         <i
           :class="bannerType === 'provider' ? 'fas fa-database' : 'fas fa-cloud'"
@@ -40,13 +40,27 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute } from 'vue-router'
 import { DataProviderPluginManager } from '@/services/DataProviderPluginManager'
 import { StoragePluginManager } from '@/services/StoragePluginManager'
 import { IndexedDBService } from '@/services/IndexedDBService'
 
 const { t } = useI18n()
+const route = useRoute()
+
+/**
+ * Pages whose whole job is already this ask.
+ *
+ * The banner is a nudge for someone using the app without a source configured.
+ * On the landing page it reproached a first-time visitor for not having set up
+ * a product they had not yet been told about — above the sentence explaining
+ * what it is. On the onboarding flow it duplicates the step on screen.
+ */
+const SELF_EXPLANATORY_ROUTES = ['/welcome', '/onboarding']
+
+const onOwnCallToAction = computed(() => SELF_EXPLANATORY_ROUTES.includes(route.path))
 
 const bannerType = ref<'provider' | 'storage' | null>(null)
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -259,42 +259,6 @@
       "totalDuration": "Total Time"
     }
   },
-  "home": {
-    "hero": {
-      "title": "Explore. Control. Share.",
-      "cta": "Get started now"
-    },
-    "features": {
-      "privacy": {
-        "title": "Privacy first",
-        "description": "Your data stays your data."
-      },
-      "openSource": {
-        "title": "Open-source",
-        "description": "Transparent and evolving by everyone."
-      },
-      "free": {
-        "title": "Free",
-        "description": "No hidden fees, forever."
-      },
-      "customizable": {
-        "title": "Customizable",
-        "description": "Choose your data providers."
-      }
-    },
-    "quickAccess": {
-      "step1": {
-        "title": "1. Connect a data provider",
-        "description": "To see your first activities, connect a data provider (Garmin, Coros, Suunto, etc.).",
-        "button": "Configure data providers"
-      },
-      "step2": {
-        "title": "2. Configure backup",
-        "description": "To secure your data, choose a backup provider (Google Drive, Dropbox, etc.).",
-        "button": "Configure backup"
-      }
-    }
-  },
   "activities": {
     "loading": "Loading...",
     "allLoaded": "All activities are loaded.",
@@ -833,5 +797,65 @@
     "publishFirst": "Publish your data from your profile first",
     "linkCopied": "Profile link copied",
     "copyFailed": "Could not copy the link"
+  },
+  "landing": {
+    "hero": {
+      "eyebrow": "Local-first · Open source · Free",
+      "title": "Your training data belongs to you.",
+      "lead": "OpenStride brings your Garmin and Strava activities together in one place, and keeps them on your device. Not on our servers.",
+      "cta": "Import my activities",
+      "ctaCode": "View the code",
+      "note": "No account to create, no subscription, no tracker."
+    },
+    "how": {
+      "title": "How it works",
+      "connect": {
+        "title": "1. Plug in your watch",
+        "text": "Garmin in a few clicks, or your Strava account archive. Your activities arrive whole: GPS track, heart rate, cadence, elevation."
+      },
+      "analyze": {
+        "title": "2. Analyse without a black box",
+        "text": "Personal records, best times, segments, progress over the year. Every calculation is open: if a number surprises you, you can go read where it came from."
+      },
+      "own": {
+        "title": "3. Stay in charge",
+        "text": "Your activities live in your browser. Cloud backup is there if you want it — you switch it on, and you pick the provider."
+      }
+    },
+    "why": {
+      "title": "Why OpenStride",
+      "privacy": {
+        "title": "Privacy",
+        "text": "No account, no tracker. Your data goes nowhere until you ask it to."
+      },
+      "openSource": {
+        "title": "Open source",
+        "text": "The code is public, and so are the algorithms. Including the ones that compute your performance."
+      },
+      "free": {
+        "title": "Free",
+        "text": "No subscription, no premium tier, nothing behind a paywall."
+      },
+      "extensible": {
+        "title": "Extensible",
+        "text": "OpenStride is built from plugins. Missing your watch, or the chart you like? It can be added."
+      }
+    },
+    "sources": {
+      "title": "Your sources",
+      "lead": "What works today. The list grows as plugins land.",
+      "garmin": {
+        "name": "Garmin Connect",
+        "how": "Direct connection"
+      },
+      "strava": {
+        "name": "Strava",
+        "how": "Import your archive — FIT, GPX and TCX included"
+      }
+    },
+    "closing": {
+      "title": "Take your data back.",
+      "text": "A few minutes to import years of training. And nothing to uninstall if you change your mind: it was yours all along."
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -259,42 +259,6 @@
       "totalDuration": "Temps total"
     }
   },
-  "home": {
-    "hero": {
-      "title": "Explorez. Contrôlez. Partagez.",
-      "cta": "Commencer maintenant"
-    },
-    "features": {
-      "privacy": {
-        "title": "Respect de votre vie privée",
-        "description": "Vos données restent vos données."
-      },
-      "openSource": {
-        "title": "Open-source",
-        "description": "Transparent et évolutif par tous."
-      },
-      "free": {
-        "title": "Gratuit",
-        "description": "Aucun frais caché, pour toujours."
-      },
-      "customizable": {
-        "title": "Personnalisable",
-        "description": "Choisissez vos fournisseurs de données."
-      }
-    },
-    "quickAccess": {
-      "step1": {
-        "title": "1. Connectez un fournisseur de données",
-        "description": "Pour pouvoir voir vos premières activités, connectez un fournisseur de données (Garmin, Coros, Suunto etc.).",
-        "button": "Configurer les fournisseurs de données"
-      },
-      "step2": {
-        "title": "2. Configurez la sauvegarde",
-        "description": "Pour sécuriser vos données, choisissez un fournisseur de sauvegarde (Google Drive, Dropbox, etc.).",
-        "button": "Configurer la sauvegarde"
-      }
-    }
-  },
   "activities": {
     "loading": "Chargement...",
     "allLoaded": "Toutes les activités sont chargées.",
@@ -833,5 +797,65 @@
     "publishFirst": "Publiez d’abord vos données depuis votre profil",
     "linkCopied": "Lien de profil copié",
     "copyFailed": "Impossible de copier le lien"
+  },
+  "landing": {
+    "hero": {
+      "eyebrow": "Local-first · Open source · Gratuit",
+      "title": "Vos données d'entraînement vous appartiennent.",
+      "lead": "OpenStride rassemble vos sorties Garmin et Strava au même endroit, et les garde sur votre appareil. Pas sur nos serveurs.",
+      "cta": "Importer mes activités",
+      "ctaCode": "Voir le code",
+      "note": "Sans compte à créer, sans abonnement, sans traceur."
+    },
+    "how": {
+      "title": "Comment ça marche",
+      "connect": {
+        "title": "1. Branchez votre montre",
+        "text": "Garmin en quelques clics, ou l'archive de votre compte Strava. Vos sorties arrivent complètes : trace GPS, fréquence cardiaque, cadence, dénivelé."
+      },
+      "analyze": {
+        "title": "2. Analysez sans boîte noire",
+        "text": "Records personnels, meilleurs temps, segments, progression sur l'année. Chaque calcul est ouvert : un chiffre vous surprend, vous pouvez aller lire d'où il sort."
+      },
+      "own": {
+        "title": "3. Gardez la main",
+        "text": "Vos activités vivent dans votre navigateur. Une sauvegarde cloud existe si vous la voulez — c'est vous qui l'allumez, et vous choisissez chez qui."
+      }
+    },
+    "why": {
+      "title": "Pourquoi OpenStride",
+      "privacy": {
+        "title": "Vie privée",
+        "text": "Aucun compte, aucun traceur. Vos données ne partent nulle part tant que vous ne l'avez pas demandé."
+      },
+      "openSource": {
+        "title": "Open source",
+        "text": "Le code est public, les algorithmes aussi. Y compris ceux qui calculent vos performances."
+      },
+      "free": {
+        "title": "Gratuit",
+        "text": "Pas d'abonnement, pas de version premium, rien derrière un paywall."
+      },
+      "extensible": {
+        "title": "Extensible",
+        "text": "OpenStride est fait de plugins. Il manque votre montre ou votre graphique préféré ? Il peut être ajouté."
+      }
+    },
+    "sources": {
+      "title": "Vos sources",
+      "lead": "Ce qui fonctionne aujourd'hui. La liste s'allonge au rythme des plugins.",
+      "garmin": {
+        "name": "Garmin Connect",
+        "how": "Connexion directe"
+      },
+      "strava": {
+        "name": "Strava",
+        "how": "Import de votre archive — FIT, GPX et TCX inclus"
+      }
+    },
+    "closing": {
+      "title": "Reprenez vos données.",
+      "text": "Quelques minutes pour importer des années d'entraînement. Et rien à désinstaller si ça ne vous plaît pas : tout est chez vous."
+    }
   }
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import ProfilePage from '@/views/ProfilePage.vue'
 import MyActivities from '@/views/MyActivities.vue'
 import ActivityDetails from '@/views/ActivityDetails.vue'
 import HomePage from '@/views/HomePage.vue'
+import LandingPage from '@/views/LandingPage.vue'
 import OnboardingFlow from '@/views/onboarding/OnboardingFlow.vue'
 import LegalPage from '@/views/LegalPage.vue'
 import CGUPage from '@/views/CGUPage.vue'
@@ -16,6 +17,7 @@ import { IndexedDBService } from '@/services/IndexedDBService'
 
 const routes = [
   { path: '/', component: HomePage },
+  { path: '/welcome', component: LandingPage },
   { path: '/onboarding', component: OnboardingFlow },
   { path: '/legal', component: LegalPage },
   { path: '/cgu', component: CGUPage },
@@ -81,25 +83,34 @@ router.beforeEach(async (to, from, next) => {
     }
   }
 
-  // Rediriger home vers activities si l'utilisateur a des données
-  if (to.path === '/') {
-    // Check own activities
-    const activityService = await getActivityService()
-    const ownActivities = await activityService.getActivities({ limit: 1, offset: 0 })
-
-    // Check friend activities
-    const db = await IndexedDBService.getInstance()
-    const friendActivities = await db.getAllData('friend_activities')
-
-    // If user has ANY activities (own or friends), stay on HomePage
-    // HomePage will show the mixed feed via ActivityFeedService
-    if (ownActivities.length > 0 || friendActivities.length > 0) {
-      // Don't redirect, let HomePage show the activity feed
-      return next()
-    }
+  /**
+   * `/` is the feed for someone who has data, and the pitch for someone who
+   * has none.
+   *
+   * The check below already existed and its answer was thrown away, so a first
+   * visitor to openstride.org landed on the feed's empty state — a page that
+   * says what is missing without ever saying what the product is.
+   *
+   * `/welcome` bounces the other way so the pitch is never a dead end for
+   * someone who already imported.
+   */
+  if (to.path === '/' || to.path === '/welcome') {
+    const wantsFeed = await hasAnyActivity()
+    const destination = wantsFeed ? '/' : '/welcome'
+    return destination === to.path ? next() : next(destination)
   }
 
   next() // continue normalement
 })
+
+async function hasAnyActivity(): Promise<boolean> {
+  const activityService = await getActivityService()
+  const own = await activityService.getActivities({ limit: 1, offset: 0 })
+  if (own.length > 0) return true
+
+  const db = await IndexedDBService.getInstance()
+  const friendActivities = await db.getAllData('friend_activities')
+  return friendActivities.length > 0
+}
 
 export default router

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -1,0 +1,399 @@
+<template>
+  <div class="landing">
+    <!-- Hero -->
+    <section class="hero">
+      <p class="hero__eyebrow">{{ t('landing.hero.eyebrow') }}</p>
+      <h1 class="hero__title">{{ t('landing.hero.title') }}</h1>
+      <p class="hero__lead">{{ t('landing.hero.lead') }}</p>
+
+      <div class="hero__actions">
+        <RouterLink to="/onboarding" class="btn btn--primary" data-test="landing-cta">
+          {{ t('landing.hero.cta') }}
+        </RouterLink>
+        <a
+          class="btn btn--ghost"
+          href="https://github.com/OpenStride/front"
+          target="_blank"
+          rel="noopener"
+        >
+          <i class="fab fa-github" aria-hidden="true"></i>
+          {{ t('landing.hero.ctaCode') }}
+        </a>
+      </div>
+
+      <p class="hero__note">
+        <i class="fas fa-circle-check" aria-hidden="true"></i>
+        {{ t('landing.hero.note') }}
+      </p>
+    </section>
+
+    <!-- iOS installs before any plugin: this is the first screen it can ask on -->
+    <InstallPrompt variant="gate" class="landing__install" />
+
+    <!-- How it works -->
+    <section class="section">
+      <h2 class="section__title">{{ t('landing.how.title') }}</h2>
+      <ol class="steps">
+        <li v-for="step in steps" :key="step.key" class="step">
+          <div class="step__icon"><i :class="step.icon" aria-hidden="true"></i></div>
+          <div>
+            <h3 class="step__title">{{ t(`landing.how.${step.key}.title`) }}</h3>
+            <p class="step__text">{{ t(`landing.how.${step.key}.text`) }}</p>
+          </div>
+        </li>
+      </ol>
+    </section>
+
+    <!-- Pillars -->
+    <section class="section">
+      <h2 class="section__title">{{ t('landing.why.title') }}</h2>
+      <div class="pillars">
+        <article v-for="pillar in pillars" :key="pillar.key" class="pillar">
+          <i class="pillar__icon" :class="pillar.icon" aria-hidden="true"></i>
+          <h3 class="pillar__title">{{ t(`landing.why.${pillar.key}.title`) }}</h3>
+          <p class="pillar__text">{{ t(`landing.why.${pillar.key}.text`) }}</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Sources -->
+    <section class="section">
+      <h2 class="section__title">{{ t('landing.sources.title') }}</h2>
+      <p class="section__lead">{{ t('landing.sources.lead') }}</p>
+      <ul class="sources">
+        <li v-for="source in sources" :key="source.key" class="source">
+          <i :class="source.icon" aria-hidden="true"></i>
+          <span class="source__name">{{ t(`landing.sources.${source.key}.name`) }}</span>
+          <span class="source__how">{{ t(`landing.sources.${source.key}.how`) }}</span>
+        </li>
+      </ul>
+    </section>
+
+    <!-- Closing -->
+    <section class="closing">
+      <h2 class="closing__title">{{ t('landing.closing.title') }}</h2>
+      <p class="closing__text">{{ t('landing.closing.text') }}</p>
+      <RouterLink to="/onboarding" class="btn btn--primary">
+        {{ t('landing.hero.cta') }}
+      </RouterLink>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { RouterLink } from 'vue-router'
+import InstallPrompt from '@/components/InstallPrompt.vue'
+
+const { t } = useI18n()
+
+// Keys drive the copy; the icons are the only thing the template decides.
+const steps = [
+  { key: 'connect', icon: 'fas fa-link' },
+  { key: 'analyze', icon: 'fas fa-chart-line' },
+  { key: 'own', icon: 'fas fa-lock' }
+]
+
+const pillars = [
+  { key: 'privacy', icon: 'fas fa-shield-halved' },
+  { key: 'openSource', icon: 'fas fa-code-branch' },
+  { key: 'free', icon: 'fas fa-gift' },
+  { key: 'extensible', icon: 'fas fa-puzzle-piece' }
+]
+
+// Only what actually works today. Coros is a ten-line stub and the zip provider
+// is deprecated, so neither is promised here — and there is no standalone
+// GPX import: those formats are read inside a Strava archive, nowhere else.
+const sources = [
+  { key: 'garmin', icon: 'fas fa-stopwatch' },
+  { key: 'strava', icon: 'fas fa-file-zipper' }
+]
+</script>
+
+<style scoped>
+.landing {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 0 1.25rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3.5rem;
+}
+
+/* ===== Hero ===== */
+.hero {
+  padding: 3.5rem 0 0;
+  text-align: center;
+}
+
+.hero__eyebrow {
+  margin: 0 0 1rem;
+  font-family: var(--font-condensed);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-green-700);
+}
+
+.hero__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2.1rem, 7vw, 3.1rem);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  color: var(--color-ink);
+  text-wrap: balance;
+}
+
+.hero__lead {
+  margin: 1.25rem auto 0;
+  max-width: 34rem;
+  font-size: 1.0625rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+  text-wrap: pretty;
+}
+
+.hero__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.hero__note {
+  margin: 1.25rem 0 0;
+  font-size: 0.875rem;
+  color: var(--text-faint);
+}
+
+.hero__note i {
+  color: var(--color-green-500);
+  margin-right: 0.4rem;
+}
+
+/* ===== Buttons ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1.75rem;
+  border-radius: var(--radius-pill);
+  font-size: 1rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.btn--primary {
+  background: var(--color-green-600);
+  color: var(--color-white);
+}
+
+.btn--primary:hover {
+  background: var(--color-green-700);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-ink);
+  border: 1px solid var(--border-subtle);
+}
+
+.btn--ghost:hover {
+  border-color: var(--color-ink-soft);
+}
+
+.landing__install {
+  margin: 0;
+}
+
+/* ===== Sections ===== */
+.section__title {
+  margin: 0 0 1.5rem;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--color-ink);
+}
+
+.section__lead {
+  margin: -1rem 0 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+/* ===== Steps ===== */
+.steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.step {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.step__icon {
+  flex-shrink: 0;
+  width: 2.75rem;
+  height: 2.75rem;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+  font-size: 1.0625rem;
+}
+
+.step__title {
+  margin: 0 0 0.3rem;
+  font-family: var(--font-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.step__text {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--text-muted);
+}
+
+/* ===== Pillars ===== */
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.pillar {
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+}
+
+.pillar__icon {
+  font-size: 1.125rem;
+  color: var(--color-green-600);
+}
+
+.pillar__title {
+  margin: 0.75rem 0 0.35rem;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.pillar__text {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--text-muted);
+}
+
+/* ===== Sources ===== */
+.sources {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.source {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  font-size: 0.9375rem;
+}
+
+.source > i {
+  color: var(--color-green-600);
+  width: 1.25rem;
+  text-align: center;
+}
+
+.source__name {
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.source__how {
+  margin-left: auto;
+  font-size: 0.8125rem;
+  color: var(--text-faint);
+  text-align: right;
+}
+
+/* ===== Closing ===== */
+.closing {
+  padding: 2.5rem 1.5rem;
+  border-radius: var(--radius-xl);
+  background: var(--color-ink);
+  text-align: center;
+}
+
+.closing__title {
+  margin: 0 0 0.75rem;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--color-white);
+}
+
+.closing__text {
+  margin: 0 auto 1.75rem;
+  max-width: 28rem;
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  color: var(--color-gray-300);
+}
+
+.closing .btn--primary {
+  background: var(--color-lime);
+  color: var(--color-ink);
+}
+
+.closing .btn--primary:hover {
+  background: var(--color-lime-soft);
+}
+
+@media (max-width: 480px) {
+  .pillars {
+    grid-template-columns: 1fr;
+  }
+
+  .source {
+    flex-wrap: wrap;
+  }
+
+  .source__how {
+    margin-left: 2rem;
+    text-align: left;
+    flex-basis: 100%;
+  }
+}
+</style>

--- a/tests/e2e/specs/test.js
+++ b/tests/e2e/specs/test.js
@@ -1,8 +1,0 @@
-// https://docs.cypress.io/api/table-of-contents
-
-describe('My First Test', () => {
-  it('Visits the app root url', () => {
-    cy.visit('/')
-    cy.contains('h1', 'Welcome to Your Vue.js + TypeScript App')
-  })
-})

--- a/tests/unit/LandingPage.spec.ts
+++ b/tests/unit/LandingPage.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import LandingPage from '@/views/LandingPage.vue'
+import fr from '@/locales/fr.json'
+import en from '@/locales/en.json'
+
+// The install gate reads platform state through a service that touches the DOM
+// and IndexedDB; the landing page's own copy is what is under test here.
+vi.mock('@/composables/useInstallPrompt', () => ({
+  useInstallPrompt: () => ({
+    offerBeforePlugins: { value: false },
+    offerAfterEngagement: { value: false },
+    canPrompt: { value: false },
+    promptInstall: vi.fn(),
+    dismiss: vi.fn()
+  })
+}))
+
+function mountIn(locale: 'fr' | 'en') {
+  const i18n = createI18n({ legacy: false, locale, messages: { fr, en } })
+  return mount(LandingPage, {
+    global: {
+      plugins: [i18n],
+      stubs: { RouterLink: { template: '<a><slot /></a>' } }
+    }
+  })
+}
+
+describe('LandingPage.vue', () => {
+  /**
+   * The page is almost entirely copy, so the failure that matters is a key that
+   * does not resolve: vue-i18n renders the key itself, and `landing.hero.title`
+   * in 48px on the front page is the kind of thing that ships.
+   *
+   * This is what happened to the `home.*` namespace this page replaces — it was
+   * written, translated into both locales, and never wired to a view at all.
+   */
+  for (const locale of ['fr', 'en'] as const) {
+    it(`resolves every key it renders in ${locale}`, () => {
+      const text = mountIn(locale).text()
+      expect(text).not.toMatch(/\blanding\./)
+      expect(text.length).toBeGreaterThan(400)
+    })
+  }
+
+  it('names only the sources that actually work', () => {
+    const text = mountIn('en').text()
+    expect(text).toContain('Garmin')
+    expect(text).toContain('Strava')
+
+    // Coros is a ten-line stub and the zip provider is deprecated. Neither can
+    // import anything, so neither may appear on the page that promises they do.
+    expect(text).not.toMatch(/Coros/i)
+    expect(text).not.toMatch(/\bZIP import\b/i)
+  })
+
+  it('gives the page exactly one first-level heading', () => {
+    const wrapper = mountIn('en')
+    expect(wrapper.findAll('h1')).toHaveLength(1)
+    expect(wrapper.get('h1').text()).toBe(en.landing.hero.title)
+  })
+
+  it('sends both calls to action into the onboarding flow', () => {
+    const wrapper = mountIn('en')
+    const ctas = wrapper.findAll('a').filter(a => a.text() === en.landing.hero.cta)
+    expect(ctas.length).toBe(2)
+  })
+})


### PR DESCRIPTION
Un visiteur qui ouvrait openstride.org tombait sur l'état vide du flux : **« Aucune activité »**, deux boutons, et un bandeau jaune lui reprochant de ne pas avoir connecté de source. La page disait ce qui manquait sans jamais dire ce qu'est le produit.

## Le début qui existait déjà

Un namespace `home.*` — un hero, quatre piliers, deux étapes — **écrit et traduit dans les deux langues, puis jamais branché à aucune vue**. Aucun composant ne lisait ces 21 clés. Il sert de base à la nouvelle copie et disparaît.

## L'angle

> **Vos données d'entraînement vous appartiennent.**

L'ancien hero, « Explorez. Contrôlez. Partagez. », est rythmé mais ne dit pas ce qu'est le produit : quelqu'un qui arrive ne sait toujours pas qu'on parle de sport. La page pose donc la promesse, puis déroule en quatre temps — ce que c'est, comment ça marche, pourquoi, avec quoi.

## Le routage

`/` sert le flux à qui a des données et le pitch à qui n'en a pas. Le garde faisait déjà exactement ce calcul et **jetait la réponse**. `/welcome` renvoie dans l'autre sens, pour que la page ne soit pas un cul-de-sac après un import — les deux redirections sont vérifiées dans un navigateur.

## La copie ne promet que ce qui existe

Le premier jet annonçait « Fichiers FIT & GPX, glissez-déposez ». Vérification faite, **il n'existe aucun import GPX autonome** : ces formats ne sont lus qu'à l'intérieur d'une archive Strava. Coros est un stub de dix lignes, ZipImport est `deprecated`.

Restent Garmin (connexion directe) et Strava (import d'archive). Un test échoue si une source non fonctionnelle réapparaît sur la page.

## Le gate iOS trouve sa place

Sur iPhone, une app ajoutée à l'écran d'accueil a **son propre stockage** : ce qui est importé dans Safari reste dans Safari. Il faut donc installer avant d'importer, et la landing est le premier écran où on peut le dire. C'est exactement la règle posée en #74, qui n'avait pas encore d'endroit où s'appliquer.

## Au passage

| | |
| --- | --- |
| Bandeau de setup | se tait sur `/welcome` et `/onboarding`, dont c'est déjà tout le propos |
| Logo du header | redevient un `span` — en `h1` il concurrençait le titre de chaque page, et la landing en avait deux |
| `tests/e2e/specs/test.js` | supprimé : ne matche pas le `specPattern` de Cypress, n'a donc **jamais tourné**, et vérifiait le texte par défaut du scaffold Vue |

## Vérifications

Rendu contrôlé dans un vrai navigateur : **français et anglais**, mobile et desktop, gate iOS compris, et les deux sens de redirection.

Les deux gardes du nouveau spec ont été validés en réintroduisant leur violation — une clé fantôme, puis Coros ajouté aux sources — avant restauration.

**678 tests** verts (+5), `typecheck` (`vue-tsc`), ESLint, Prettier et build propres.

## Non traité

La nav du header (« Mes activités / Statistiques / Amis / Profil / ACTUALISER ») s'affiche sur la landing alors que ces écrans sont tous vides pour un nouvel arrivant. Ça se défend — ça montre ce que fait l'app — mais « ACTUALISER » n'a rien à actualiser. À trancher séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_