### PR TITLE
refactor(profile): faire des amis et du partage une seule section

### DIFF
--- a/plugins/app-extensions/ProfileSharing/ProfileSharingTab.vue
+++ b/plugins/app-extensions/ProfileSharing/ProfileSharingTab.vue
@@ -1,46 +1,39 @@
 <template>
-  <div class="space-y-6">
-    <!-- A section of the friends tab, not a page of its own -->
-    <h3 class="text-lg font-bold">{{ t('profile.sharePrivacy') }}</h3>
+  <section class="sharing">
+    <header class="sharing__head">
+      <h3 class="sharing__title">{{ t('profile.myPublicProfile') }}</h3>
+      <p class="sharing__lead">{{ t('profile.myPublicProfileLead') }}</p>
+    </header>
 
     <!-- What the section is for, so it comes first rather than under a
          privacy dropdown and a publish button -->
-    <div v-if="publicUrl" class="bg-white shadow p-6 space-y-3">
-      <p class="text-sm font-medium text-gray-700 text-center">
-        {{ t('profile.scanToFollow') }}
-      </p>
+    <div v-if="publicUrl" class="card card--center">
+      <p class="card__label">{{ t('profile.scanToFollow') }}</p>
       <QRCodeDisplay :url="publicUrl" />
     </div>
 
     <!-- Publishing needs a cloud provider that can host public files. Saying so
          here beats letting the button fail with "upload error". -->
-    <div
-      v-if="!checkingSupport && !canPublish"
-      class="border border-amber-300 bg-amber-50 p-4 space-y-3"
-      data-test="publish-requires-storage"
-    >
-      <p class="text-sm font-medium text-amber-900">
-        <i class="fas fa-circle-info mr-1" aria-hidden="true"></i>
+    <div v-if="!checkingSupport && !canPublish" class="notice" data-test="publish-requires-storage">
+      <p class="notice__title">
+        <i class="fas fa-circle-info" aria-hidden="true"></i>
         {{ t('profile.publishNeedsStorage') }}
       </p>
-      <p class="text-xs text-amber-800">{{ t('profile.publishNeedsStorageHelp') }}</p>
-      <router-link
-        to="/profile?tab=cloud-backup"
-        class="inline-flex items-center gap-2 rounded-md bg-amber-600 px-4 py-2 text-sm text-white hover:bg-amber-700"
-      >
+      <p class="notice__text">{{ t('profile.publishNeedsStorageHelp') }}</p>
+      <router-link to="/profile?tab=cloud-backup" class="btn btn--notice">
         <i class="fas fa-cloud" aria-hidden="true"></i>
         {{ t('profile.connectStorage') }}
       </router-link>
     </div>
 
-    <!-- Publish Button -->
     <button
       v-else
       @click="publishData"
       :disabled="publishing || checkingSupport"
-      class="w-full bg-green-600 text-white py-2 rounded-md hover:bg-green-700 disabled:bg-gray-400"
+      class="btn btn--primary btn--block"
       data-test="publish-button"
     >
+      <i class="fas fa-cloud-arrow-up" aria-hidden="true"></i>
       {{
         publishing
           ? t('profile.publishing')
@@ -52,36 +45,33 @@
 
     <!-- Keeping the published copy fresh is the whole point of publishing: a
          profile frozen on the day it was created is what friends see otherwise. -->
-    <div v-if="publicUrl" class="bg-white shadow p-6 space-y-3">
-      <label class="flex items-center gap-3">
+    <div v-if="publicUrl" class="card">
+      <label class="toggle">
         <input
           type="checkbox"
           :checked="autoPublish"
           @change="toggleAutoPublish"
-          class="h-4 w-4"
           data-test="auto-publish-toggle"
         />
-        <span class="text-sm font-medium text-gray-700">{{ t('profile.autoPublish') }}</span>
+        <span class="toggle__label">{{ t('profile.autoPublish') }}</span>
       </label>
-      <p class="text-xs text-gray-500">{{ t('profile.autoPublishHint') }}</p>
+      <p class="card__hint">{{ t('profile.autoPublishHint') }}</p>
     </div>
 
-    <!-- Privacy Settings -->
-    <div class="bg-white shadow p-6 space-y-4">
-      <label class="text-sm font-medium text-gray-700">{{ t('profile.defaultPrivacy') }}</label>
+    <div class="card">
+      <label class="card__label" for="default-privacy">{{ t('profile.defaultPrivacy') }}</label>
       <select
+        id="default-privacy"
         v-model="defaultPrivacy"
         @change="saveDefaultPrivacy"
-        class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
+        class="select"
       >
         <option value="private">{{ t('profile.private') }}</option>
         <option value="public">{{ t('profile.public') }}</option>
       </select>
-      <p class="text-xs text-gray-500">
-        {{ t('profile.privacyHint') }}
-      </p>
+      <p class="card__hint">{{ t('profile.privacyHint') }}</p>
     </div>
-  </div>
+  </section>
 </template>
 
 <script setup lang="ts">
@@ -104,8 +94,8 @@ const autoPublish = ref(false)
 // Toasts for friend events are raised once by the app layout — not here
 onMounted(async () => {
   // Load privacy settings
-  const privacySetting = await storage.getData('defaultPrivacy')
-  defaultPrivacy.value = (privacySetting as string as 'public' | 'private') || 'private'
+  const privacySetting = await storage.getData<string>('defaultPrivacy')
+  defaultPrivacy.value = (privacySetting as 'public' | 'private') || 'private'
 
   // Load public URL if available
   publicUrl.value = await friends.getMyPublicUrl()
@@ -146,3 +136,167 @@ const toggleAutoPublish = async (event: Event) => {
   })
 }
 </script>
+
+<style scoped>
+/* The tokens below are the same ones the friends list uses, so the two halves
+   of this tab read as one section rather than two components that met. */
+.sharing {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sharing__head {
+  margin-bottom: 0.25rem;
+}
+
+.sharing__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.sharing__lead {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.card--center {
+  align-items: center;
+}
+
+.card__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.card__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--text-faint);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  cursor: pointer;
+}
+
+.toggle input {
+  width: 1.0625rem;
+  height: 1.0625rem;
+  accent-color: var(--color-green-600);
+  flex-shrink: 0;
+}
+
+.toggle__label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+
+.select {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-ink);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.select:focus {
+  outline: 2px solid var(--color-green-400);
+  outline-offset: 1px;
+}
+
+/* The app already has a warning tone — the setup banner uses it a few pixels
+   above this block. Tailwind's amber was a second one on the same screen. */
+.notice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: var(--color-yellow-50);
+  border: 1px solid var(--color-yellow-200);
+  border-radius: var(--radius-md);
+}
+
+.notice__title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-yellow-800);
+}
+
+.notice__text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-yellow-800);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.2s;
+}
+
+.btn--block {
+  width: 100%;
+}
+
+.btn--primary {
+  background: var(--color-green-600);
+  color: var(--color-white);
+}
+
+.btn--primary:hover:not(:disabled) {
+  background: var(--color-green-700);
+}
+
+.btn--primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--notice {
+  align-self: flex-start;
+  background: var(--color-yellow-500);
+  color: var(--color-white);
+}
+
+.btn--notice:hover {
+  background: var(--color-yellow-600);
+}
+</style>

--- a/src/assets/styles/variables.css
+++ b/src/assets/styles/variables.css
@@ -94,7 +94,12 @@
   --color-red-600: #dc2626;
   --color-red-800: #991b1b;
 
+  /* 50 and 200 complete the scale: a warning surface light enough to sit under
+     body text needed them, and their absence is why a plugin reached for
+     Tailwind's amber instead — a second warning tone on the same screen. */
+  --color-yellow-50: #fffbeb;
   --color-yellow-100: #fef3c7;
+  --color-yellow-200: #fde68a;
   --color-yellow-500: #f59e0b;
   --color-yellow-600: #d97706;
   --color-yellow-800: #92400e;

--- a/src/components/profile/ProfileFriends.vue
+++ b/src/components/profile/ProfileFriends.vue
@@ -9,130 +9,146 @@
       class="friends-sharing"
     />
 
-    <div class="page-header">
-      <div class="header-actions">
-        <button @click="refreshAll" :disabled="refreshing" class="refresh-btn">
-          <i :class="['fas fa-sync icon', { spinning: refreshing }]" aria-hidden="true"></i>
-          {{ t('friendsList.sync') }}
-        </button>
-        <button @click="qrOpen = true" class="qr-btn" data-test="open-my-qr">
-          <i class="fas fa-qrcode icon" aria-hidden="true"></i>
-          {{ t('myQr.title') }}
-        </button>
-        <button @click="openScanner" class="add-btn">
-          <i class="fas fa-user-plus icon" aria-hidden="true"></i>
-          {{ t('friends.addFriend') }}
-        </button>
-      </div>
-    </div>
+    <section class="friends-block">
+      <div class="block-bar">
+        <h3 class="block-title">
+          {{ t('friendsList.title') }}
+          <span v-if="friends.length" class="block-count">{{ friends.length }}</span>
+        </h3>
 
-    <div v-if="loading" class="loading">
-      <p>{{ t('common.loading') }}</p>
-    </div>
-
-    <div v-else-if="friends.length === 0" class="empty-state">
-      <div class="empty-icon">
-        <i class="fas fa-user-friends" aria-hidden="true"></i>
-      </div>
-      <p class="empty-title">{{ t('friendsList.empty') }}</p>
-      <p class="empty-description">
-        {{ t('friendsList.emptyHelp') }}
-      </p>
-      <button @click="openScanner" class="empty-action-btn">
-        <i class="fas fa-qrcode" aria-hidden="true"></i>
-        {{ t('friendsList.scanQr') }}
-      </button>
-    </div>
-
-    <div v-else class="friends-list">
-      <div v-for="friend in friends" :key="friend.id" class="friend-card">
-        <div class="friend-avatar">
-          <img
-            v-if="friend.profilePhoto"
-            :src="friend.profilePhoto"
-            :alt="friend.username"
-            class="avatar-img"
-          />
-          <div v-else class="avatar-placeholder">
-            {{ friend.username.charAt(0).toUpperCase() }}
+        <!-- Adding a friend is why anyone opens this tab, so on a phone it gets
+             the full width and the only filled button. Sync and the QR code are
+             things you come back for, and share the row below. -->
+        <div class="actions">
+          <button @click="openScanner" class="btn btn--primary" data-test="add-friend">
+            <i class="fas fa-user-plus" aria-hidden="true"></i>
+            {{ t('friends.addFriend') }}
+          </button>
+          <div class="actions__secondary">
+            <button @click="qrOpen = true" class="btn btn--quiet" data-test="open-my-qr">
+              <i class="fas fa-qrcode" aria-hidden="true"></i>
+              {{ t('myQr.title') }}
+            </button>
+            <button
+              @click="refreshAll"
+              :disabled="refreshing"
+              class="btn btn--quiet"
+              data-test="sync-friends"
+            >
+              <i :class="['fas fa-sync', { spinning: refreshing }]" aria-hidden="true"></i>
+              {{ t('friendsList.sync') }}
+            </button>
           </div>
         </div>
+      </div>
 
-        <div class="friend-info">
-          <h3 class="friend-name">{{ friend.username }}</h3>
-          <p v-if="friend.bio" class="friend-bio">{{ friend.bio }}</p>
+      <div v-if="loading" class="loading">
+        <p>{{ t('common.loading') }}</p>
+      </div>
 
-          <!-- Following is one-way until they add you back, and that decides
+      <div v-else-if="friends.length === 0" class="empty-state">
+        <div class="empty-icon">
+          <i class="fas fa-user-friends" aria-hidden="true"></i>
+        </div>
+        <p class="empty-title">{{ t('friendsList.empty') }}</p>
+        <!-- No button here: "Add a friend" sits a few pixels above and opens
+             the same scanner. Two buttons for one action is not an empty state,
+             it is a duplicate. -->
+        <p class="empty-description">
+          {{ t('friendsList.emptyHelp') }}
+        </p>
+      </div>
+
+      <div v-else class="friends-list">
+        <div v-for="friend in friends" :key="friend.id" class="friend-card">
+          <div class="friend-avatar">
+            <img
+              v-if="friend.profilePhoto"
+              :src="friend.profilePhoto"
+              :alt="friend.username"
+              class="avatar-img"
+            />
+            <div v-else class="avatar-placeholder">
+              {{ friend.username.charAt(0).toUpperCase() }}
+            </div>
+          </div>
+
+          <div class="friend-info">
+            <h4 class="friend-name">{{ friend.username }}</h4>
+            <p v-if="friend.bio" class="friend-bio">{{ friend.bio }}</p>
+
+            <!-- Following is one-way until they add you back, and that decides
                whether likes and comments work at all -->
-          <span
-            :class="['mutual-badge', { mutual: friend.followsMe }]"
-            :data-test="`mutual-${friend.id}`"
-          >
-            <i
-              :class="friend.followsMe ? 'fas fa-arrow-right-arrow-left' : 'fas fa-arrow-right'"
-              aria-hidden="true"
-            ></i>
-            {{ friend.followsMe ? t('friendsList.mutual') : t('friendsList.notMutual') }}
-          </span>
-
-          <div class="friend-meta">
-            <span class="meta-item">{{
-              t('friendsList.addedOn', { date: formatDate(friend.addedAt) })
-            }}</span>
-            <span v-if="friend.lastFetched" class="meta-item">
-              {{ t('friendsList.lastSync', { time: formatRelativeTime(friend.lastFetched) }) }}
+            <span
+              :class="['mutual-badge', { mutual: friend.followsMe }]"
+              :data-test="`mutual-${friend.id}`"
+            >
+              <i
+                :class="friend.followsMe ? 'fas fa-arrow-right-arrow-left' : 'fas fa-arrow-right'"
+                aria-hidden="true"
+              ></i>
+              {{ friend.followsMe ? t('friendsList.mutual') : t('friendsList.notMutual') }}
             </span>
+
+            <div class="friend-meta">
+              <span class="meta-item">{{
+                t('friendsList.addedOn', { date: formatDate(friend.addedAt) })
+              }}</span>
+              <span v-if="friend.lastFetched" class="meta-item">
+                {{ t('friendsList.lastSync', { time: formatRelativeTime(friend.lastFetched) }) }}
+              </span>
+            </div>
+          </div>
+
+          <div class="friend-actions">
+            <button
+              @click="refreshFriend(friend.id)"
+              :disabled="refreshingFriend === friend.id"
+              class="action-btn refresh"
+              :title="t('friendsList.sync')"
+            >
+              <i
+                :class="['fas fa-sync icon-sm', { spinning: refreshingFriend === friend.id }]"
+                aria-hidden="true"
+              ></i>
+            </button>
+
+            <!-- Sync All button -->
+            <button
+              v-if="friend.syncEnabled && !friend.fullySynced"
+              @click="syncAllActivities(friend.id)"
+              :disabled="syncingFriendId === friend.id"
+              class="action-btn sync-all"
+              :title="t('friendsList.syncFull')"
+            >
+              <i
+                v-if="syncingFriendId === friend.id"
+                class="fas fa-spinner fa-spin icon-sm"
+                aria-hidden="true"
+              ></i>
+              <i v-else class="fas fa-history icon-sm" aria-hidden="true"></i>
+            </button>
+
+            <!-- Show badge if fully synced -->
+            <span
+              v-if="friend.fullySynced"
+              class="fully-synced-badge"
+              :title="t('friendsList.syncedFull')"
+            >
+              <i class="fas fa-check-circle" aria-hidden="true"></i>
+            </span>
+
+            <button
+              @click="confirmRemove(friend)"
+              class="action-btn remove"
+              :title="t('friendsList.remove')"
+            >
+              <i class="fas fa-trash-alt" aria-hidden="true"></i>
+            </button>
           </div>
         </div>
-
-        <div class="friend-actions">
-          <button
-            @click="refreshFriend(friend.id)"
-            :disabled="refreshingFriend === friend.id"
-            class="action-btn refresh"
-            :title="t('friendsList.sync')"
-          >
-            <i
-              :class="['fas fa-sync icon-sm', { spinning: refreshingFriend === friend.id }]"
-              aria-hidden="true"
-            ></i>
-          </button>
-
-          <!-- Sync All button -->
-          <button
-            v-if="friend.syncEnabled && !friend.fullySynced"
-            @click="syncAllActivities(friend.id)"
-            :disabled="syncingFriendId === friend.id"
-            class="action-btn sync-all"
-            :title="t('friendsList.syncFull')"
-          >
-            <i
-              v-if="syncingFriendId === friend.id"
-              class="fas fa-spinner fa-spin icon-sm"
-              aria-hidden="true"
-            ></i>
-            <i v-else class="fas fa-history icon-sm" aria-hidden="true"></i>
-          </button>
-
-          <!-- Show badge if fully synced -->
-          <span
-            v-if="friend.fullySynced"
-            class="fully-synced-badge"
-            :title="t('friendsList.syncedFull')"
-          >
-            <i class="fas fa-check-circle" aria-hidden="true"></i>
-          </span>
-
-          <button
-            @click="confirmRemove(friend)"
-            class="action-btn remove"
-            :title="t('friendsList.remove')"
-          >
-            <i class="fas fa-trash-alt" aria-hidden="true"></i>
-          </button>
-        </div>
       </div>
-    </div>
+    </section>
 
     <!-- QR Scanner Modal -->
     <!-- Scanning navigates to /add-friend for confirmation; nothing to reload here -->
@@ -285,70 +301,95 @@ const formatRelativeTime = (timestamp: number): string => {
 .profile-friends {
   max-width: 800px;
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.page-header {
+.friends-block {
   display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  margin-bottom: 2rem;
-  flex-wrap: wrap;
-  gap: 1rem;
-}
-
-.header-actions {
-  display: flex;
+  flex-direction: column;
   gap: 0.75rem;
 }
 
-.refresh-btn,
-.qr-btn,
-.add-btn {
+.block-title {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.block-count {
+  padding: 0.05rem 0.45rem;
+  border-radius: var(--radius-pill);
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+/* Mobile first: the primary action owns a full row, the two secondary ones
+   split the next. Before this they were three stacked buttons of three
+   different widths, centred, which read as an accident. */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.actions__secondary {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.actions__secondary .btn {
+  flex: 1;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
   padding: 0.625rem 1rem;
   border: none;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background 0.2s;
 }
 
-.refresh-btn,
-.qr-btn {
-  background: var(--color-gray-100);
-  color: var(--color-gray-700);
+.btn--primary {
+  background: var(--color-green-600);
+  color: var(--color-white);
 }
 
-.qr-btn:hover {
-  background: var(--color-gray-200);
+.btn--primary:hover {
+  background: var(--color-green-700);
 }
 
-.refresh-btn:hover:not(:disabled) {
-  background: var(--color-gray-200);
+.btn--quiet {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--color-ink);
 }
 
-.refresh-btn:disabled {
+.btn--quiet:hover:not(:disabled) {
+  background: var(--surface-2);
+}
+
+.btn--quiet:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.add-btn {
-  background: var(--color-green-500);
-  color: var(--color-white);
-}
-
-.add-btn:hover {
-  background: var(--color-green-600);
-}
-
-.icon {
-  font-size: 1rem;
-}
-
-.icon.spinning {
+.spinning {
   animation: spin 1s linear infinite;
 }
 
@@ -367,66 +408,68 @@ const formatRelativeTime = (timestamp: number): string => {
   color: var(--color-gray-500);
 }
 
+/* The empty state sits inside the section that already names itself, so it
+   repeats neither the title nor the icon at hero size. */
 .empty-state {
   text-align: center;
-  padding: 4rem 2rem;
+  padding: 2rem 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
 }
 
 .empty-icon {
-  font-size: 4rem;
-  margin-bottom: 1rem;
+  font-size: 1.75rem;
+  color: var(--color-green-500);
+  margin-bottom: 0.75rem;
 }
 
 .empty-title {
-  font-size: 1.5rem;
-  font-weight: 600;
-  color: var(--color-gray-900);
-  margin-bottom: 0.5rem;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-ink);
+  margin: 0 0 0.35rem;
 }
 
 .empty-description {
-  color: var(--color-gray-500);
-  margin-bottom: 2rem;
-}
-
-.empty-action-btn {
-  padding: 0.75rem 1.5rem;
-  background: var(--color-green-500);
-  color: var(--color-white);
-  border: none;
-  border-radius: 0.5rem;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-}
-
-.empty-action-btn:hover {
-  background: var(--color-green-600);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  margin: 0 auto 1.25rem;
+  max-width: 22rem;
 }
 
 .friends-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
+/* A grid, not a flex row: on mobile the actions used to wrap onto their own
+   line while the avatar stayed vertically centred against the whole card,
+   leaving a hole beneath it. Here the avatar is pinned to the top row and the
+   actions drop under the text they act on. */
 .friend-card {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 1.25rem;
-  background: var(--color-white);
-  border-radius: 0.75rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 0.5rem 0.875rem;
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
   transition: box-shadow 0.2s;
 }
 
 .friend-card:hover {
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 10px rgba(30, 30, 46, 0.09);
 }
 
 .friend-avatar {
-  flex-shrink: 0;
+  grid-column: 1;
+  grid-row: 1;
 }
 
 .avatar-img,
@@ -441,28 +484,31 @@ const formatRelativeTime = (timestamp: number): string => {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-green-500);
+  background: var(--color-green-600);
   color: var(--color-white);
-  font-size: 1.5rem;
-  font-weight: 600;
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
 .friend-info {
-  flex: 1;
+  grid-column: 2;
+  grid-row: 1;
   min-width: 0;
 }
 
 .friend-name {
-  font-size: 1.125rem;
-  font-weight: 600;
-  margin: 0 0 0.25rem;
-  color: var(--color-gray-900);
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 0.15rem;
+  color: var(--color-ink);
 }
 
 .friend-bio {
-  font-size: 0.875rem;
-  color: var(--color-gray-500);
-  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  margin: 0 0 0.35rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -470,16 +516,17 @@ const formatRelativeTime = (timestamp: number): string => {
 
 .friend-meta {
   display: flex;
-  gap: 1rem;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
   font-size: 0.75rem;
-  color: var(--color-gray-400);
+  color: var(--text-faint);
 }
 
 .mutual-badge {
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
-  margin: 0.25rem 0 0.5rem;
+  margin: 0 0 0.4rem;
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius-pill);
   font-size: 0.7rem;
@@ -495,47 +542,46 @@ const formatRelativeTime = (timestamp: number): string => {
   color: var(--color-green-700);
 }
 
+/* Under the text on mobile, alongside it once there is room. */
 .friend-actions {
+  grid-column: 2;
+  grid-row: 2;
   display: flex;
-  gap: 0.5rem;
+  gap: 0.375rem;
   flex-shrink: 0;
 }
 
 .action-btn {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.25rem;
+  height: 2.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
   border: none;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 1.125rem;
+  font-size: 1rem;
   transition: background 0.2s;
 }
 
-.action-btn.refresh {
-  background: var(--color-gray-100);
-}
-
-.action-btn.refresh:hover:not(:disabled) {
-  background: var(--color-gray-200);
-}
-
-.action-btn.refresh:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
+/* Quick sync and full-history sync are the same kind of act — one reaches
+   further back — so they share one neutral treatment. Colour is reserved for
+   the two things that are not neutral: the destructive one, and the state
+   badge. Three buttons wore four colours before this. */
+.action-btn.refresh,
 .action-btn.sync-all {
-  background: var(--color-blue-100);
-  color: var(--color-blue-800);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
 }
 
+.action-btn.refresh:hover:not(:disabled),
 .action-btn.sync-all:hover:not(:disabled) {
-  background: var(--color-blue-200);
+  background: var(--surface-muted);
+  color: var(--color-ink);
 }
 
+.action-btn.refresh:disabled,
 .action-btn.sync-all:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -543,6 +589,7 @@ const formatRelativeTime = (timestamp: number): string => {
 
 .action-btn.remove {
   background: var(--color-red-100);
+  color: var(--color-red-800);
 }
 
 .action-btn.remove:hover {
@@ -625,39 +672,59 @@ const formatRelativeTime = (timestamp: number): string => {
   background: var(--color-red-600);
 }
 
+/* Sized like the action buttons it sits between, so the row keeps one rhythm
+   whether a friend is fully synced or still has a button there. The brand
+   green, not emerald: "fully synced" and "follows you" are both positive
+   states in the same card and were two different greens. */
 .fully-synced-badge {
+  width: 2.25rem;
+  height: 2.25rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.375rem 0.75rem;
-  background: var(--color-emerald-100);
-  color: var(--color-emerald-800);
-  border-radius: 0.375rem;
-  font-size: 0.75rem;
-  font-weight: 500;
+  justify-content: center;
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
 }
 
-.fully-synced-badge i {
-  font-size: 0.875rem;
+.block-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-@media (max-width: 640px) {
-  .page-header {
-    flex-direction: column;
-    align-items: stretch;
+/* From here up it is one column; the width buys back the second row, and the
+   title shares it with the actions. */
+@media (min-width: 40rem) {
+  .block-bar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 
-  .header-actions {
-    flex-direction: column;
+  .actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+
+  .actions__secondary {
+    order: -1;
+  }
+
+  .actions__secondary .btn {
+    flex: 0 0 auto;
   }
 
   .friend-card {
-    flex-wrap: wrap;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    padding: 1.125rem 1.25rem;
   }
 
   .friend-actions {
-    width: 100%;
-    justify-content: flex-end;
+    grid-column: 3;
+    grid-row: 1;
   }
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -256,7 +256,9 @@
       "totalActivities": "Activities",
       "totalDistance": "Total Distance",
       "totalDuration": "Total Time"
-    }
+    },
+    "myPublicProfile": "My public profile",
+    "myPublicProfileLead": "What your friends see of you, and how often it refreshes."
   },
   "activities": {
     "loading": "Loading...",
@@ -617,7 +619,6 @@
   "friendsList": {
     "empty": "No friend added",
     "emptyHelp": "Scan a friend's QR code to start following their activities",
-    "scanQr": "Scan a QR code",
     "sync": "Sync",
     "syncFull": "Sync the full history",
     "syncedFull": "Full history synced",
@@ -627,7 +628,8 @@
     "mutual": "Follows you",
     "notMutual": "Doesn't follow you yet",
     "addedOn": "Added {date}",
-    "lastSync": "Synced {time}"
+    "lastSync": "Synced {time}",
+    "title": "My friends"
   },
   "activityDetailPage": {
     "friendActivity": "Activity by",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -256,7 +256,9 @@
       "totalActivities": "Activités",
       "totalDistance": "Distance totale",
       "totalDuration": "Temps total"
-    }
+    },
+    "myPublicProfile": "Mon profil public",
+    "myPublicProfileLead": "Ce que vos amis voient de vous, et à quelle fréquence c'est rafraîchi."
   },
   "activities": {
     "loading": "Chargement...",
@@ -617,7 +619,6 @@
   "friendsList": {
     "empty": "Aucun ami ajouté",
     "emptyHelp": "Scannez le QR code d'un ami pour commencer à suivre ses activités",
-    "scanQr": "Scanner un QR Code",
     "sync": "Synchroniser",
     "syncFull": "Synchroniser l'historique complet",
     "syncedFull": "Historique complet synchronisé",
@@ -627,7 +628,8 @@
     "mutual": "Vous suit",
     "notMutual": "Ne vous suit pas encore",
     "addedOn": "Ajouté le {date}",
-    "lastSync": "Sync {time}"
+    "lastSync": "Sync {time}",
+    "title": "Mes amis"
   },
   "activityDetailPage": {
     "friendActivity": "Activité de",

--- a/tests/unit/ProfileFriends.spec.ts
+++ b/tests/unit/ProfileFriends.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import ProfileFriends from '@/components/profile/ProfileFriends.vue'
+import fr from '@/locales/fr.json'
+import en from '@/locales/en.json'
+import type { Friend } from '@/types/friend'
+
+const FRIENDS: Friend[] = [
+  {
+    id: 'f1',
+    username: 'Camille',
+    publicUrl: 'https://example.test/1',
+    addedAt: 1_700_000_000_000,
+    lastFetched: 1_700_000_500_000,
+    syncEnabled: true,
+    followsMe: true,
+    fullySynced: true
+  },
+  {
+    id: 'f2',
+    username: 'Bruno',
+    publicUrl: 'https://example.test/2',
+    addedAt: 1_700_000_000_000,
+    syncEnabled: true,
+    followsMe: false
+  }
+]
+
+const getAllFriends = vi.fn(async () => FRIENDS)
+
+vi.mock('@/services/FriendService', () => ({
+  FriendService: {
+    getInstance: () => ({
+      getAllFriends: () => getAllFriends(),
+      refreshAllFriends: vi.fn(),
+      syncFriendActivitiesQuick: vi.fn(),
+      syncFriendActivitiesAll: vi.fn(),
+      removeFriend: vi.fn()
+    })
+  }
+}))
+
+vi.mock('@/composables/useSlotExtensions', () => ({
+  useSlotExtensions: () => ({ components: { value: [] } })
+}))
+
+async function mountIn(locale: 'fr' | 'en', friends: Friend[] = FRIENDS) {
+  getAllFriends.mockResolvedValueOnce(friends)
+  const i18n = createI18n({ legacy: false, locale, messages: { fr, en } })
+  const wrapper = mount(ProfileFriends, {
+    global: {
+      plugins: [i18n],
+      stubs: { QRScanner: true, MyQrCodeModal: true, RouterLink: true }
+    }
+  })
+  await new Promise(r => setTimeout(r, 0))
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ProfileFriends.vue', () => {
+  /**
+   * The tab is called "Friends & sharing" and only sharing carried a heading.
+   * The list below simply started, which is why the action row read as
+   * belonging to the privacy card above it rather than to the friends.
+   */
+  it('names the friends half of the tab', async () => {
+    const wrapper = await mountIn('en')
+    expect(wrapper.text()).toContain(en.friendsList.title)
+  })
+
+  /**
+   * One action, one button. The empty state used to offer "Scan a QR code"
+   * a few pixels under "Add a friend", and both opened the same scanner.
+   */
+  it('offers a single way to add a friend, list empty or not', async () => {
+    for (const friends of [FRIENDS, []]) {
+      const wrapper = await mountIn('en', friends)
+      const openers = wrapper
+        .findAll('button')
+        .filter(b => b.text().includes(en.friends.addFriend) || /scan/i.test(b.text()))
+      expect(openers).toHaveLength(1)
+    }
+  })
+
+  for (const locale of ['fr', 'en'] as const) {
+    it(`resolves every key it renders in ${locale}`, async () => {
+      const text = (await mountIn(locale)).text()
+      expect(text).not.toMatch(/\b(friendsList|friends|myQr)\./)
+    })
+  }
+})


### PR DESCRIPTION
L'onglet s'appelle « Amis & partage » et **seul le partage portait un titre**. La liste en dessous commençait sans rien annoncer, ce qui faisait lire la barre d'actions comme appartenant à la carte de confidentialité au-dessus d'elle plutôt qu'aux amis.

Les deux moitiés venaient de deux composants qui ne s'étaient jamais parlé : le plugin de partage en cartes à angles droits, la liste d'amis en cartes arrondies, empilées l'une sur l'autre.

## Sur mobile, où le problème se voyait le plus

| Avant | Après |
| --- | --- |
| Trois boutons empilés de trois largeurs différentes, centrés | « Ajouter un ami » en pleine largeur — c'est pour ça qu'on ouvre l'onglet — QR code et synchro sur la ligne suivante, à parts égales |
| La carte ami renvoyait ses actions à la ligne pendant que l'avatar restait centré verticalement sur toute la hauteur, laissant un trou dessous | Une grille : avatar épinglé à la première ligne, actions sous le texte sur lequel elles agissent |
| État vide avec icône 4rem **et son propre bouton**, qui appelait la même fonction qu'« Ajouter un ami » 80px plus haut | La section se nomme elle-même ; le bouton en double est parti |

## Trois couleurs qui n'en faisaient qu'une de trop

- **Le bloc d'alerte** tombait sur l'ambre **par défaut de Tailwind**, alors que le bandeau de setup, quelques pixels plus haut, utilise le jaune de l'app. L'échelle `--color-yellow-*` était trouée (100/500/600/800) : les crans 50 et 200 manquaient, et c'est exactement ce qui a poussé le plugin ailleurs. Ils sont ajoutés.
- **« Synchroniser » gris et « historique complet » bleu**, alors que c'est le même geste à deux profondeurs. Trois boutons portaient quatre couleurs. La couleur est désormais réservée au destructif et à l'état.
- **La pastille « entièrement synchronisé » en emerald** quand le badge « vous suit » est en vert de marque — deux verts pour deux états positifs dans la même carte.

### Ce qui n'était PAS un problème

Le diagnostic de départ supposait que le `bg-green-600` du plugin jurait avec l'olive de la marque. Mesure faite dans le navigateur : il rend `#4d7314`, soit exactement `--color-green-600`. **Tailwind v4 lit les `--color-*` de `:root`**, donc verts et gris sont déjà alignés — seules les teintes que l'app ne définit pas (amber) tombaient sur la palette par défaut. Aucun changement n'a été fait sur cette base.

## Vérifications

Rendu contrôlé dans un vrai navigateur en **390px et 1100px**, liste pleine et liste vide, en français.

**739 tests** verts (+4), `typecheck` (`vue-tsc`), ESLint, Prettier et build propres. Le test du bouton en double a été validé en le réintroduisant avant restauration.

Au passage, `friendsList.scanQr` n'a plus de consommateur et disparaît des deux locales.

## Deux choses relevées, non traitées ici

1. **Le `format:check` de la CI ne couvre que `src/**`.** `plugins/` et `tests/` ont dérivé — Prettier voulait reformater 11 fichiers sans rapport avec ce changement. Ils ont été sortis du diff pour qu'il reste lisible, mais la brèche mérite sa propre PR.
2. **Les autres onglets du profil restent en utilitaires Tailwind** (`bg-white shadow p-6`, `text-2xl font-bold`) là où celui-ci passe en CSS scopé sur tokens, comme le veulent les guidelines. Harmoniser les quatre autres est un choix à part entière, pas un à-côté de celui-ci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_