### PR TITLE
Harmoniser l'en-tête de la liste, et retirer l'entrée amis du menu

### DIFF
--- a/src/components/ActivityFilters.vue
+++ b/src/components/ActivityFilters.vue
@@ -285,6 +285,9 @@ function onDateTo(e: Event) {
   background: var(--surface);
   color: var(--text-color);
   font-size: 0.8rem;
+  /* Same reason as the scope tabs: a sport name is a label, not a shout */
+  text-transform: none;
+  letter-spacing: 0;
   cursor: pointer;
   transition:
     background 0.2s,

--- a/src/components/ActivityFilters.vue
+++ b/src/components/ActivityFilters.vue
@@ -249,10 +249,12 @@ function onDateTo(e: Event) {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem;
-  background: var(--color-white);
-  border: 1px solid var(--color-gray-200);
-  border-radius: 8px;
+  padding: 0.85rem;
+  /* Nested one level inside the controls panel, so it recedes rather than
+     repeating the surface it sits on */
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
 }
 
 .filter-section {
@@ -264,7 +266,7 @@ function onDateTo(e: Event) {
 .filter-label {
   font-size: 0.8rem;
   font-weight: 600;
-  color: var(--color-gray-500);
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
@@ -277,9 +279,10 @@ function onDateTo(e: Event) {
 
 .chip {
   padding: 0.35rem 0.75rem;
-  border-radius: 20px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--color-green-200);
-  background: var(--bg-color);
+  /* Raised on the recessed panel, the way the selected scope tab is */
+  background: var(--surface);
   color: var(--text-color);
   font-size: 0.8rem;
   cursor: pointer;
@@ -319,11 +322,11 @@ function onDateTo(e: Event) {
 .range-input {
   width: 100%;
   padding: 0.5rem 2.2rem 0.5rem 0.6rem;
-  border: 1px solid var(--color-gray-200);
-  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
   font-size: 0.85rem;
   font-family: var(--font-main);
-  background: var(--color-white);
+  background: var(--surface);
   color: var(--text-color);
   -moz-appearance: textfield;
 }
@@ -351,7 +354,7 @@ function onDateTo(e: Event) {
 .range-unit {
   position: absolute;
   right: 0.6rem;
-  color: var(--color-gray-400);
+  color: var(--text-faint);
   font-size: 0.8rem;
   pointer-events: none;
 }

--- a/src/components/ActivitySearchBar.vue
+++ b/src/components/ActivitySearchBar.vue
@@ -86,11 +86,13 @@ function onInput(e: Event) {
 .search-input {
   width: 100%;
   padding: 0.6rem 2rem 0.6rem 2.25rem;
-  border: 1px solid var(--color-gray-200);
-  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
   font-size: 0.9rem;
   font-family: var(--font-main);
-  background: var(--color-white);
+  /* Recessed: the row now sits on a white panel, and a white field on a white
+     panel is only findable by its hairline */
+  background: var(--surface-2);
   color: var(--text-color);
   transition: border-color 0.2s;
 }
@@ -126,10 +128,10 @@ function onInput(e: Event) {
   justify-content: center;
   width: 40px;
   height: 40px;
-  border: 1px solid var(--color-gray-200);
-  border-radius: 8px;
-  background: var(--color-white);
-  color: var(--color-gray-500);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-2);
+  color: var(--text-muted);
   cursor: pointer;
   transition: all 0.2s;
   flex-shrink: 0;

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -43,7 +43,9 @@
         :key="`nav-${i}`"
         @navigate="closeMenu"
       />
-      <router-link to="/?who=friends" @click="closeMenu">{{ t('navigation.friends') }}</router-link>
+      <!-- No entry for friends: they are a scope of the list, reachable from
+           its own tabs. A menu line leading to `/?who=friends` was a second
+           door onto a tab already on screen. -->
       <router-link to="/profile" @click="closeMenu">{{ t('navigation.profile') }}</router-link>
       <button class="refresh-btn" @click="onRefresh" :disabled="refreshing">
         <span :class="['icon', { spinning: refreshing }]" aria-hidden="true">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,7 +118,6 @@
   "navigation": {
     "home": "Home",
     "profile": "Profile",
-    "friends": "Friends",
     "dataProviders": "Data Providers",
     "storageProviders": "Storage Providers",
     "appExtensions": "App Extensions",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -118,7 +118,6 @@
   "navigation": {
     "home": "Accueil",
     "profile": "Profil",
-    "friends": "Amis",
     "dataProviders": "Sources de données",
     "storageProviders": "Stockage cloud",
     "appExtensions": "Extensions",

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -229,9 +229,12 @@ function onFiltersChange(newFilters: ActivityFilters) {
 }
 
 /* A track inside a panel, so it takes the recessed surface rather than the
-   grey it used to borrow from the page background */
+   grey it used to borrow from the page background. Capped, because three short
+   words stretched across six hundred pixels read as an empty row rather than as
+   a control — on a phone the cap is wider than the screen, so it fills. */
 .scope-tabs {
   display: flex;
+  max-width: 22rem;
   gap: 0.2rem;
   background: var(--surface-2);
   border: 1px solid var(--border-subtle);
@@ -249,6 +252,10 @@ function onFiltersChange(newFilters: ActivityFilters) {
   font-family: var(--font-main);
   font-size: 0.85rem;
   font-weight: 500;
+  /* Global button styling shouts in uppercase; a scope is a label, not a call
+     to action, and the friend chips below already opted out of it */
+  text-transform: none;
+  letter-spacing: 0;
   cursor: pointer;
   transition: all 0.2s;
 }

--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -196,7 +196,11 @@ function onFiltersChange(newFilters: ActivityFilters) {
 </script>
 
 <style scoped>
+/* One rhythm for the whole column: `--home-gap` is the gap the cards already
+   keep between themselves, so the goals block, the controls and the first card
+   are all spaced alike instead of each picking their own value. */
 .home-page {
+  --home-gap: 1.25rem;
   max-width: 600px;
   margin: 0 auto;
   padding: 0;
@@ -205,34 +209,43 @@ function onFiltersChange(newFilters: ActivityFilters) {
 .home-top {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  margin-bottom: 1rem;
+  gap: 0.75rem;
+  margin-bottom: var(--home-gap);
 }
 
-/* One rhythm for the whole column: the search row, the scope tabs and the
-   filter panel are spaced like the cards are spaced between themselves */
+/* Same treatment as a card — surface, hairline, shadow, square corners — so
+   the controls read as a block of the page rather than as an extension of the
+   sticky header they sit under. Two white boxes a few pixels apart read as one
+   region, which is what put the search bar inside the header. */
 .home-controls {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  padding: 0.85rem;
+  margin-bottom: var(--home-gap);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-card);
 }
 
+/* A track inside a panel, so it takes the recessed surface rather than the
+   grey it used to borrow from the page background */
 .scope-tabs {
   display: flex;
-  gap: 0.25rem;
-  background: var(--color-gray-100);
-  border-radius: 8px;
+  gap: 0.2rem;
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
   padding: 0.2rem;
 }
 
 .scope-tab {
   flex: 1;
-  padding: 0.45rem 0.6rem;
+  padding: 0.4rem 0.6rem;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--color-gray-500);
+  color: var(--text-muted);
   font-family: var(--font-main);
   font-size: 0.85rem;
   font-weight: 500;
@@ -240,10 +253,14 @@ function onFiltersChange(newFilters: ActivityFilters) {
   transition: all 0.2s;
 }
 
+.scope-tab:hover:not(.is-active) {
+  color: var(--text-color);
+}
+
 .scope-tab.is-active {
-  background: var(--color-white);
-  color: var(--color-gray-900);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  background: var(--surface);
+  color: var(--text-color);
+  box-shadow: var(--shadow-card);
 }
 
 .friends-empty {
@@ -273,9 +290,10 @@ function onFiltersChange(newFilters: ActivityFilters) {
   font-size: 0.875rem;
 }
 
+/* Sits last inside the panel, so it needs no margin of its own */
 .result-count {
-  font-size: 0.85rem;
-  color: var(--color-gray-500);
+  font-size: 0.8rem;
+  color: var(--text-muted);
   margin: 0;
 }
 
@@ -316,9 +334,8 @@ function onFiltersChange(newFilters: ActivityFilters) {
     padding: 0;
   }
 
-  .home-top,
-  .home-controls {
-    margin-bottom: 0.75rem;
+  .home-page {
+    --home-gap: 1rem;
   }
 }
 </style>


### PR DESCRIPTION
Suite de #82. Deux commits : l'entrée « Amis » du menu, et les espacements en tête de liste.

## L'entrée « Amis » du menu

Supprimée, avec sa clé de traduction. Les amis sont une portée de la liste, atteignable depuis ses propres onglets — une ligne de menu vers `/?who=friends` était une seconde porte vers un onglet déjà à l'écran.

## Le haut de la liste

La barre de recherche est une boîte blanche posée sur le fond de page, à vingt pixels sous un en-tête blanc collant qui porte une ombre. Deux surfaces blanches si proches se lisent comme une seule zone, et la recherche paraissait appartenir à l'en-tête.

Les contrôles prennent donc le traitement d'une carte — `--surface`, filet `--border-subtle`, `--shadow-card`, angles droits — et se lisent comme un bloc de la page. Le langage existait déjà dans `ActivityCard` ; il n'est pas inventé ici. Les champs qu'ils contiennent passent en surface creusée : un champ blanc sur un panneau blanc ne se trouve qu'à son filet. Le panneau de filtres, imbriqué d'un niveau de plus, recule d'autant.

Les espacements suivaient trois valeurs pour trois voisins. Ils tiennent maintenant à `--home-gap`, qui vaut l'écart que les cartes gardent déjà entre elles.

## Ce que les captures ont corrigé

Le rendu a été vérifié dans un navigateur, ce qui a fait remonter deux défauts invisibles dans le diff :

- **Les libellés criaient.** Les onglets affichaient `ALL / ME / FRIENDS` et les jetons de sport `STRENGTH TRAINING` : la feuille globale met `text-transform: uppercase` sur tout `button`, et ces deux séries l'héritaient — alors que les jetons amis juste en dessous s'en étaient explicitement désinscrits. Une portée et un nom de sport sont des étiquettes, pas des appels à l'action.
- **La piste d'onglets s'étalait.** Trois mots courts sur six cents pixels lisaient comme une rangée vide plutôt que comme un contrôle. Elle est bornée à 22 rem ; sur téléphone la borne dépasse la largeur d'écran, donc elle remplit toujours.

Au passage, les jetons de sport, libellés et unités des filtres passent aux variables sémantiques (`--text-muted`, `--text-faint`, `--radius-pill`) au lieu de piocher dans l'échelle de gris.

## Vérifications

- Rendu vérifié sur captures headless, en 1280 et en 390, sur trois états : liste, panneau de filtres ouvert, portée amis. Aucune erreur JS.
- 735 tests unitaires verts
- `format:check`, `vue-tsc` et `eslint` propres
- Build de production lancé et OK

## Un point signalé, pas traité

L'onglet actif porte un contour bleu au clic : `button:focus { outline: 2px solid rgba(0, 123, 255, 0.5) }` dans la feuille globale. C'est hors marque, et `:focus-visible` conviendrait mieux que `:focus` — mais c'est une règle globale qui touche toute l'application, elle mérite sa propre décision plutôt qu'un changement au détour de ce lot.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMQkXbT1q5sfEuJGbNYsFX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMQkXbT1q5sfEuJGbNYsFX)_