### PR TITLE
feat(profile): dire ce que les amis voient, au lieu de le laisser deviner

### DIFF
--- a/plugins/app-extensions/ProfileSharing/ProfileSharingTab.vue
+++ b/plugins/app-extensions/ProfileSharing/ProfileSharingTab.vue
@@ -5,11 +5,33 @@
       <p class="sharing__lead">{{ t('profile.myPublicProfileLead') }}</p>
     </header>
 
-    <!-- What the section is for, so it comes first rather than under a
-         privacy dropdown and a publish button -->
-    <div v-if="publicUrl" class="card card--center">
-      <p class="card__label">{{ t('profile.scanToFollow') }}</p>
-      <QRCodeDisplay :url="publicUrl" />
+    <!-- The state of the profile, not the mechanics of it.
+         A 450px QR code used to sit here, and the same code — same component,
+         same link, same copy button — is one tap away behind "My QR code".
+         What was missing is what a friend actually receives. -->
+    <div v-if="publicUrl" class="card status" data-test="public-status">
+      <p class="status__line">
+        <i class="fas fa-users status__icon" aria-hidden="true"></i>
+        <span>{{
+          t('profile.sharedCount', { count: summary.activityCount }, summary.activityCount)
+        }}</span>
+      </p>
+      <p v-if="summary.publishedAt" class="status__line status__line--faint">
+        <i class="fas fa-clock-rotate-left status__icon" aria-hidden="true"></i>
+        <span>{{ t('profile.publishedAt', { time: relativePublished }) }}</span>
+      </p>
+
+      <!-- `defaultPrivacy` ships as `private`, so publishing without touching
+           it produces a profile a friend can follow and find empty. Nothing
+           said so before. -->
+      <p v-if="summary.activityCount === 0" class="status__empty" data-test="nothing-shared">
+        {{ t('profile.nothingShared') }}
+      </p>
+
+      <button @click="qrOpen = true" class="btn btn--quiet" data-test="show-my-qr">
+        <i class="fas fa-qrcode" aria-hidden="true"></i>
+        {{ t('profile.shareMyProfile') }}
+      </button>
     </div>
 
     <!-- Publishing needs a cloud provider that can host public files. Saying so
@@ -71,14 +93,16 @@
       </select>
       <p class="card__hint">{{ t('profile.privacyHint') }}</p>
     </div>
+
+    <MyQrCodeModal :is-open="qrOpen" @close="qrOpen = false" />
   </section>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { usePluginContext } from '@/composables/usePluginContext'
-import QRCodeDisplay from '@/components/QRCodeDisplay.vue'
+import MyQrCodeModal from '@/components/MyQrCodeModal.vue'
 
 const { t } = useI18n()
 const { storage, notifications, friends } = usePluginContext()
@@ -90,6 +114,22 @@ const publishing = ref(false)
 const canPublish = ref(false)
 const checkingSupport = ref(true)
 const autoPublish = ref(false)
+const qrOpen = ref(false)
+const summary = ref<{ activityCount: number; publishedAt: number | null }>({
+  activityCount: 0,
+  publishedAt: null
+})
+
+const relativePublished = computed(() => {
+  if (!summary.value.publishedAt) return ''
+  const days = Math.floor((Date.now() - summary.value.publishedAt) / 86_400_000)
+  if (days < 1) return t('time.today')
+  return t('time.daysAgo', { count: days }, days)
+})
+
+const loadSummary = async () => {
+  summary.value = await friends.getPublicSummary()
+}
 
 // Toasts for friend events are raised once by the app layout — not here
 onMounted(async () => {
@@ -99,6 +139,7 @@ onMounted(async () => {
 
   // Load public URL if available
   publicUrl.value = await friends.getMyPublicUrl()
+  if (publicUrl.value) await loadSummary()
 
   canPublish.value = await friends.canPublish()
   checkingSupport.value = false
@@ -108,6 +149,9 @@ onMounted(async () => {
 // Privacy & Sharing functions
 const saveDefaultPrivacy = async () => {
   await storage.saveData('defaultPrivacy', defaultPrivacy.value)
+  // The count above is a direct consequence of this setting — the whole point
+  // of showing it is that it answers back.
+  if (publicUrl.value) await loadSummary()
 }
 
 const publishData = async () => {
@@ -116,6 +160,7 @@ const publishData = async () => {
     const url = await friends.publishPublicData()
     if (url) {
       publicUrl.value = url
+      await loadSummary()
       // The first publish arms auto-publish, so reflect the new state
       autoPublish.value = await friends.isAutoPublishEnabled()
     }
@@ -176,8 +221,44 @@ const toggleAutoPublish = async (event: Event) => {
   box-shadow: var(--shadow-card);
 }
 
-.card--center {
+.status__line {
+  display: flex;
   align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-ink);
+}
+
+.status__line--faint {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.status__icon {
+  width: 1rem;
+  text-align: center;
+  color: var(--color-green-600);
+}
+
+.status__line--faint .status__icon {
+  color: var(--text-faint);
+}
+
+.status__empty {
+  margin: 0.25rem 0 0;
+  padding: 0.625rem 0.75rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-yellow-50);
+  color: var(--color-yellow-800);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.status .btn {
+  align-self: flex-start;
+  margin-top: 0.25rem;
 }
 
 .card__label {
@@ -288,6 +369,16 @@ const toggleAutoPublish = async (event: Event) => {
 .btn--primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.btn--quiet {
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  color: var(--color-ink);
+}
+
+.btn--quiet:hover {
+  background: var(--surface-2);
 }
 
 .btn--notice {

--- a/src/components/profile/ProfileFriends.vue
+++ b/src/components/profile/ProfileFriends.vue
@@ -16,29 +16,24 @@
           <span v-if="friends.length" class="block-count">{{ friends.length }}</span>
         </h3>
 
-        <!-- Adding a friend is why anyone opens this tab, so on a phone it gets
-             the full width and the only filled button. Sync and the QR code are
-             things you come back for, and share the row below. -->
+        <!-- Two actions, both about the people in this list. "My QR code" used
+             to sit here too, but it is about me, not about them — it belongs to
+             the public-profile section above, and having it in both places was
+             one modal behind two doors. -->
         <div class="actions">
           <button @click="openScanner" class="btn btn--primary" data-test="add-friend">
             <i class="fas fa-user-plus" aria-hidden="true"></i>
             {{ t('friends.addFriend') }}
           </button>
-          <div class="actions__secondary">
-            <button @click="qrOpen = true" class="btn btn--quiet" data-test="open-my-qr">
-              <i class="fas fa-qrcode" aria-hidden="true"></i>
-              {{ t('myQr.title') }}
-            </button>
-            <button
-              @click="refreshAll"
-              :disabled="refreshing"
-              class="btn btn--quiet"
-              data-test="sync-friends"
-            >
-              <i :class="['fas fa-sync', { spinning: refreshing }]" aria-hidden="true"></i>
-              {{ t('friendsList.sync') }}
-            </button>
-          </div>
+          <button
+            @click="refreshAll"
+            :disabled="refreshing"
+            class="btn btn--quiet"
+            data-test="sync-friends"
+          >
+            <i :class="['fas fa-sync', { spinning: refreshing }]" aria-hidden="true"></i>
+            {{ t('friendsList.sync') }}
+          </button>
         </div>
       </div>
 
@@ -154,8 +149,6 @@
     <!-- Scanning navigates to /add-friend for confirmation; nothing to reload here -->
     <QRScanner :is-open="scannerOpen" @close="scannerOpen = false" />
 
-    <MyQrCodeModal :is-open="qrOpen" @close="qrOpen = false" />
-
     <!-- Remove Confirmation Modal -->
     <div v-if="friendToRemove" class="modal-overlay" @click.self="friendToRemove = null">
       <div class="modal-content">
@@ -178,7 +171,6 @@ import { ref, computed, onMounted } from 'vue'
 import { FriendService } from '@/services/FriendService'
 import { useSlotExtensions } from '@/composables/useSlotExtensions'
 import QRScanner from '@/components/QRScanner.vue'
-import MyQrCodeModal from '@/components/MyQrCodeModal.vue'
 import type { Friend } from '@/types/friend'
 
 const { t, locale } = useI18n()
@@ -194,7 +186,6 @@ const refreshing = ref(false)
 const refreshingFriend = ref<string | null>(null)
 const syncingFriendId = ref<string | null>(null)
 const scannerOpen = ref(false)
-const qrOpen = ref(false)
 const friendToRemove = ref<Friend | null>(null)
 
 // Toasts for friend events are handled once, in the layout
@@ -340,15 +331,6 @@ const formatRelativeTime = (timestamp: number): string => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.actions__secondary {
-  display: flex;
-  gap: 0.5rem;
-}
-
-.actions__secondary .btn {
-  flex: 1;
 }
 
 .btn {
@@ -706,14 +688,6 @@ const formatRelativeTime = (timestamp: number): string => {
   .actions {
     flex-direction: row;
     justify-content: flex-end;
-  }
-
-  .actions__secondary {
-    order: -1;
-  }
-
-  .actions__secondary .btn {
-    flex: 0 0 auto;
   }
 
   .friend-card {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -221,7 +221,6 @@
     "publishing": "Publishing...",
     "updateData": "Update",
     "publishData": "Publish my data",
-    "scanToFollow": "Scan this code to follow me",
     "publishNeedsStorage": "Publishing needs a cloud provider",
     "publishNeedsStorageHelp": "Your public profile is hosted on your own cloud storage. Connect Google Drive to publish it and let friends follow you.",
     "connectStorage": "Connect a provider",
@@ -257,7 +256,11 @@
       "totalDuration": "Total Time"
     },
     "myPublicProfile": "My public profile",
-    "myPublicProfileLead": "What your friends see of you, and how often it refreshes."
+    "myPublicProfileLead": "What your friends see of you, and how often it refreshes.",
+    "sharedCount": "{count} activity shared | {count} activities shared",
+    "publishedAt": "Published {time}",
+    "nothingShared": "Your friends see nothing yet: your activities are private by default. Switch the default below to public, or open a single activity to share just that one.",
+    "shareMyProfile": "Share my profile"
   },
   "activities": {
     "loading": "Loading...",
@@ -677,7 +680,8 @@
     "justNow": "just now",
     "minutesAgo": "{count} min ago",
     "hoursAgo": "{count}h ago",
-    "daysAgo": "{count}d ago"
+    "daysAgo": "{count}d ago",
+    "today": "today"
   },
   "friendEvents": {
     "invalidShareUrl": "Invalid share link",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -221,7 +221,6 @@
     "publishing": "Publication...",
     "updateData": "Mettre à jour",
     "publishData": "Publier mes données",
-    "scanToFollow": "Scannez ce code pour me suivre",
     "publishNeedsStorage": "La publication nécessite un espace cloud",
     "publishNeedsStorageHelp": "Votre profil public est hébergé sur votre propre espace cloud. Connectez Google Drive pour le publier et permettre à vos amis de vous suivre.",
     "connectStorage": "Connecter un espace",
@@ -257,7 +256,11 @@
       "totalDuration": "Temps total"
     },
     "myPublicProfile": "Mon profil public",
-    "myPublicProfileLead": "Ce que vos amis voient de vous, et à quelle fréquence c'est rafraîchi."
+    "myPublicProfileLead": "Ce que vos amis voient de vous, et à quelle fréquence c'est rafraîchi.",
+    "sharedCount": "{count} activité partagée | {count} activités partagées",
+    "publishedAt": "Publié {time}",
+    "nothingShared": "Vos amis ne voient rien pour l'instant : vos activités sont privées par défaut. Passez la confidentialité en public ci-dessous, ou ouvrez une activité pour la partager seule.",
+    "shareMyProfile": "Partager mon profil"
   },
   "activities": {
     "loading": "Chargement...",
@@ -677,7 +680,8 @@
     "justNow": "à l'instant",
     "minutesAgo": "il y a {count} min",
     "hoursAgo": "il y a {count}h",
-    "daysAgo": "il y a {count}j"
+    "daysAgo": "il y a {count}j",
+    "today": "aujourd'hui"
   },
   "friendEvents": {
     "invalidShareUrl": "Lien de partage invalide",

--- a/src/services/PluginContextFactory.ts
+++ b/src/services/PluginContextFactory.ts
@@ -6,6 +6,7 @@ import { aggregationService } from './AggregationService'
 import { FriendService } from './FriendService'
 import { PublicFileService } from './PublicFileService'
 import { getPublicDataListener } from './PublicDataListener'
+import { PublicDataPublisher } from './PublicDataPublisher'
 import { ActivityAnalyzer } from './ActivityAnalyzer'
 import { DataProviderPluginManager } from './DataProviderPluginManager'
 import { StoragePluginManager } from './StoragePluginManager'
@@ -97,6 +98,7 @@ export async function createPluginContext(): Promise<PluginContext> {
       getMyManifestUrl: () => FriendService.getInstance().getMyManifestUrl(),
       getMyPublicUrl: () => FriendService.getInstance().getMyPublicUrl(),
       canPublish: () => PublicFileService.getInstance().hasPublicFileSupport(),
+      getPublicSummary: () => PublicDataPublisher.getInstance().getPublicSummary(),
       isAutoPublishEnabled: () => getPublicDataListener().isAutoPublishEnabled(),
       setAutoPublish: enabled =>
         enabled

--- a/src/services/PublicDataPublisher.ts
+++ b/src/services/PublicDataPublisher.ts
@@ -110,6 +110,9 @@ export class PublicDataPublisher {
       }
 
       await db.saveData('myPublicUrl', manifestUrl)
+      // With auto-publish off, this is the only way to tell a fresh profile
+      // from one frozen three months ago.
+      await db.saveData('myPublicPublishedAt', Date.now())
       const shareUrl = ShareUrlService.wrapManifestUrl(manifestUrl)
 
       this.emitEvent({
@@ -193,5 +196,23 @@ export class PublicDataPublisher {
   public async hasPublishedData(): Promise<boolean> {
     const url = await this.getMyPublicUrl()
     return url !== null && url !== undefined
+  }
+
+  /**
+   * What the profile screen needs to state rather than imply: how many
+   * activities a friend receives, and how stale the published copy is.
+   *
+   * `publishedAt` is null for a profile published before the timestamp
+   * existed — unknown, which is not the same as never.
+   */
+  public async getPublicSummary(): Promise<{
+    activityCount: number
+    publishedAt: number | null
+  }> {
+    const db = await IndexedDBService.getInstance()
+    return {
+      activityCount: await PublicDataService.getInstance().countPublicActivities(),
+      publishedAt: (await db.getData<number>('myPublicPublishedAt')) ?? null
+    }
   }
 }

--- a/src/services/PublicDataService.ts
+++ b/src/services/PublicDataService.ts
@@ -75,6 +75,25 @@ export class PublicDataService {
   }
 
   /**
+   * How many activities a friend would actually receive.
+   *
+   * Answers this through the same predicate the publisher uses, so the number
+   * on screen and the number uploaded cannot drift apart. It matters because
+   * `defaultPrivacy` ships as `private`: publishing without touching it
+   * produces a profile a friend can follow and find empty.
+   */
+  public async countPublicActivities(): Promise<number> {
+    const db = await IndexedDBService.getInstance()
+    const allActivities: Activity[] = await db.getAllData<Activity>('activities')
+
+    let count = 0
+    for (const activity of allActivities) {
+      if (await this.isActivityPublic(activity.id)) count += 1
+    }
+    return count
+  }
+
+  /**
    * Generate public activities grouped by year
    */
   public async generateYearFiles(): Promise<Map<number, YearActivities>> {

--- a/src/types/plugin-context.ts
+++ b/src/types/plugin-context.ts
@@ -191,6 +191,12 @@ export interface IFriendService {
   canPublish(): Promise<boolean>
   isAutoPublishEnabled(): Promise<boolean>
   setAutoPublish(enabled: boolean): Promise<void>
+  /**
+   * What a friend actually receives, so a screen can state it instead of
+   * implying it. `publishedAt` is null when the profile predates the
+   * timestamp — unknown, not never.
+   */
+  getPublicSummary(): Promise<{ activityCount: number; publishedAt: number | null }>
   onEvent(event: string, handler: (...args: unknown[]) => void): void
   offEvent(event: string, handler: (...args: unknown[]) => void): void
 }

--- a/tests/unit/ProfileFriends.spec.ts
+++ b/tests/unit/ProfileFriends.spec.ts
@@ -71,6 +71,19 @@ describe('ProfileFriends.vue', () => {
   })
 
   /**
+   * The friends bar holds the two acts that concern the people in the list.
+   * "My QR code" is about me, so it moved to the public-profile section above
+   * — it was the same modal behind two doors on one screen.
+   */
+  it('keeps the friends bar to actions about friends', async () => {
+    const wrapper = await mountIn('en')
+    expect(wrapper.find('[data-test="add-friend"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="sync-friends"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="open-my-qr"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(en.myQr.title)
+  })
+
+  /**
    * One action, one button. The empty state used to offer "Scan a QR code"
    * a few pixels under "Add a friend", and both opened the same scanner.
    */

--- a/tests/unit/plugins/ProfileSharingTab.spec.ts
+++ b/tests/unit/plugins/ProfileSharingTab.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import ProfileSharingTab from '@plugins/app-extensions/ProfileSharing/ProfileSharingTab.vue'
+import { PLUGIN_CONTEXT_KEY } from '@/composables/usePluginContext'
+import fr from '@/locales/fr.json'
+import en from '@/locales/en.json'
+
+function contextWith(summary: { activityCount: number; publishedAt: number | null }) {
+  return {
+    storage: { getData: async () => 'private', saveData: async () => {} },
+    notifications: { notify: vi.fn() },
+    friends: {
+      getMyPublicUrl: async () => 'https://drive.example.test/uc?id=ABC',
+      canPublish: async () => true,
+      isAutoPublishEnabled: async () => false,
+      setAutoPublish: vi.fn(),
+      publishPublicData: vi.fn(),
+      getPublicSummary: async () => summary
+    }
+  }
+}
+
+async function mountWith(
+  summary: { activityCount: number; publishedAt: number | null },
+  locale: 'fr' | 'en' = 'fr'
+) {
+  const i18n = createI18n({ legacy: false, locale, messages: { fr, en } })
+  const wrapper = mount(ProfileSharingTab, {
+    global: {
+      plugins: [i18n],
+      provide: { [PLUGIN_CONTEXT_KEY]: contextWith(summary) },
+      stubs: { MyQrCodeModal: true, RouterLink: true }
+    }
+  })
+  await new Promise(r => setTimeout(r, 0))
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('ProfileSharingTab.vue', () => {
+  /**
+   * A 256px QR canvas used to open this section, and the same code — same
+   * component, same link, same copy button — sat one tap away behind "My QR
+   * code". The section is about the state of the profile; sharing it is an
+   * occasional act and belongs behind the button that already existed.
+   */
+  it('does not render a second copy of the QR code inline', async () => {
+    const wrapper = await mountWith({ activityCount: 4, publishedAt: Date.now() })
+    expect(wrapper.find('canvas').exists()).toBe(false)
+    expect(wrapper.find('[data-test="show-my-qr"]').exists()).toBe(true)
+  })
+
+  /**
+   * `defaultPrivacy` ships as `private`, so publishing without touching it
+   * produces a profile a friend can follow and find empty. The screen showed a
+   * QR code to share it and never mentioned that it contained nothing.
+   */
+  it('says so when a published profile contains nothing', async () => {
+    const wrapper = await mountWith({ activityCount: 0, publishedAt: Date.now() })
+    expect(wrapper.find('[data-test="nothing-shared"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain(fr.profile.nothingShared)
+  })
+
+  it('stays quiet once something is actually shared', async () => {
+    const wrapper = await mountWith({ activityCount: 4, publishedAt: Date.now() })
+    expect(wrapper.find('[data-test="nothing-shared"]').exists()).toBe(false)
+  })
+
+  it('counts in the singular for one activity, plural otherwise', async () => {
+    expect((await mountWith({ activityCount: 1, publishedAt: null })).text()).toContain(
+      '1 activité partagée'
+    )
+    const many = (await mountWith({ activityCount: 4, publishedAt: null })).text()
+    expect(many).toContain('4 activités partagées')
+    // Zero takes the plural in French, and must not leak the raw `a | b` source
+    const none = (await mountWith({ activityCount: 0, publishedAt: null })).text()
+    expect(none).toContain('0 activités partagées')
+    expect(none).not.toContain('|')
+  })
+
+  /** Unknown is not never: a profile published before the timestamp existed. */
+  it('omits the publication date when it was never recorded', async () => {
+    const wrapper = await mountWith({ activityCount: 2, publishedAt: null })
+    expect(wrapper.text()).not.toContain('Publié')
+  })
+
+  for (const locale of ['fr', 'en'] as const) {
+    it(`resolves every key it renders in ${locale}`, async () => {
+      const text = (await mountWith({ activityCount: 0, publishedAt: Date.now() }, locale)).text()
+      expect(text).not.toMatch(/\b(profile|time)\.[a-z]/i)
+    })
+  }
+})


### PR DESCRIPTION
Le grand QR en tête de « Mon profil public » était **le même composant, la même URL et le même bouton « Copier le lien »** que la modale ouverte par « Mon QR code » quelques centimètres plus bas. Le même code deux fois sur un écran, dont un qui coûtait 450 px en permanence.

## Ce qu'il occupait est ce qui manquait

La section proposait les **mécanismes** — publier, basculer, partager — et jamais l'**état**. Elle affiche maintenant ce qu'un athlète vient y chercher :

| | |
| --- | --- |
| **Combien d'activités ses amis reçoivent** | Compté par le prédicat exact qu'utilise le publieur (`isActivityPublic`), pour que le chiffre à l'écran et le chiffre téléversé ne puissent pas diverger |
| **Depuis quand la copie publique date** | Avec la republication auto désactivée, rien ne distinguait un profil frais d'un profil figé depuis trois mois. `myPublicPublishedAt` est écrit à la publication |

## Le cas que personne ne signalait

**`defaultPrivacy` vaut `private` par défaut.** Publier sans y toucher produit donc un profil qu'un ami peut suivre et trouver **vide** — et l'écran montrait un QR à faire scanner sans jamais dire qu'il ne menait à rien.

Il le dit maintenant, avec le renvoi vers le réglage juste en dessous. Et le compteur répond en direct quand on bascule : vérifié dans le navigateur, `0 activités partagées` → `7 activités partagées`, bandeau d'alerte qui apparaît et disparaît avec.

## Où vit le partage

« Mon QR code » quitte la barre des amis pour la section du profil : **c'est moi, pas eux**. La barre garde les deux gestes qui concernent la liste — ajouter, synchroniser.

Le raccourci de `FriendsQuickActions` sur le fil d'accueil reste en place : autre écran, autre contexte, pas un doublon.

## Architecture

`getPublicSummary()` est exposé via `PluginContext` comme le veulent les guidelines — le plugin n'importe aucun service. Le comptage vit dans `PublicDataService`, à côté du prédicat qu'il réutilise.

## Un bug attrapé par les tests, pas par le navigateur

**`time.today` n'existait dans aucune locale.** Un profil publié le jour même affichait la clé brute. Les captures de vérification seedaient « il y a 3 jours », donc la branche n'était jamais atteinte à l'écran — c'est l'assertion de résolution de clés qui l'a sortie. Clé ajoutée dans les deux locales.

Au passage, `profile.scanToFollow` n'a plus de consommateur et disparaît.

## Vérifications

Rendu contrôlé dans un vrai navigateur en **390px**, défaut privé et défaut public, y compris la bascule à chaud et l'ouverture de la modale de partage depuis la section.

**747 tests** verts (+8), `typecheck` (`vue-tsc`), ESLint, Prettier et build propres.

## Le choix produit, si tu veux le renverser

L'hypothèse retenue : un sportif consulte cet onglet pour vérifier son état et ajouter quelqu'un, et ne sort son QR qu'en présence de l'autre — d'où le code derrière un bouton plutôt qu'à l'écran en permanence. Si montrer le code doit rester le geste principal de la section, il se remonte sans rien casser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_