### PR TITLE
refactor(profile): un seul vocabulaire pour les sept onglets

### DIFF
--- a/plugins/app-extensions/MCP/ProfileMCP.vue
+++ b/plugins/app-extensions/MCP/ProfileMCP.vue
@@ -1,211 +1,127 @@
 <template>
-  <div class="space-y-6">
-    <h2 class="text-2xl font-bold">{{ t('profile.mcp.title') }}</h2>
+  <div class="profile-panel">
+    <section>
+      <h3>{{ t('profile.mcp.title') }}</h3>
+      <p class="panel-lead">{{ t('profile.mcp.description') }}</p>
 
-    <p class="text-gray-600">
-      {{ t('profile.mcp.description') }}
-    </p>
-
-    <!-- Warning if Google Drive not connected -->
-    <div
-      v-if="!isGDriveConnected"
-      class="bg-yellow-50 border border-yellow-200 p-4 flex items-start gap-3"
-    >
-      <i class="fas fa-exclamation-triangle text-yellow-600 mt-1" aria-hidden="true"></i>
-      <div class="flex-1">
-        <p class="font-semibold text-yellow-900">{{ t('profile.mcp.gdriveRequired') }}</p>
-        <p class="text-sm text-yellow-800 mt-1">{{ t('profile.mcp.gdriveRequiredHelp') }}</p>
-        <button
-          @click="goToCloudBackup"
-          class="mt-3 px-4 py-2 bg-yellow-600 text-white rounded-md hover:bg-yellow-700 text-sm font-medium"
-        >
-          <i class="fas fa-cloud mr-2" aria-hidden="true"></i>
+      <!-- Publishing rides on the same cloud space as the public profile, so
+           without one there is nothing for an assistant to read. -->
+      <div v-if="!isGDriveConnected" class="notice">
+        <p class="notice__title">
+          <i class="fas fa-circle-info" aria-hidden="true"></i>
+          {{ t('profile.mcp.gdriveRequired') }}
+        </p>
+        <p class="notice__text">{{ t('profile.mcp.gdriveRequiredHelp') }}</p>
+        <button @click="goToCloudBackup" class="btn btn--notice">
+          <i class="fas fa-cloud" aria-hidden="true"></i>
           {{ t('profile.mcp.goToCloudBackup') }}
         </button>
       </div>
-    </div>
+    </section>
 
-    <!-- MCP Configuration -->
-    <div v-else class="space-y-6">
-      <!-- Step 1: Publish Data -->
-      <div class="bg-white shadow p-6">
-        <div class="flex items-start gap-3 mb-4">
-          <div
-            class="flex-shrink-0 w-8 h-8 bg-green-600 text-white rounded-full flex items-center justify-center font-bold"
-          >
-            1
-          </div>
-          <div class="flex-1">
-            <h3 class="text-lg font-semibold text-gray-900">
-              {{ t('profile.mcp.step1Title') }}
-            </h3>
-            <p class="text-sm text-gray-600 mt-1">{{ t('profile.mcp.step1Help') }}</p>
-          </div>
-        </div>
+    <template v-if="isGDriveConnected">
+      <section>
+        <h3><span class="step">1</span>{{ t('profile.mcp.step1Title') }}</h3>
+        <p class="panel-lead">{{ t('profile.mcp.step1Help') }}</p>
 
-        <div class="flex items-center gap-3">
-          <button
-            @click="handlePublish"
-            :disabled="publishing"
-            class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:bg-gray-300 disabled:cursor-not-allowed font-medium"
-          >
+        <div class="card">
+          <button @click="handlePublish" :disabled="publishing" class="btn btn--primary">
             <i
-              :class="['fas', publishing ? 'fa-spinner fa-spin' : 'fa-sync-alt', 'mr-2']"
+              :class="['fas', publishing ? 'fa-spinner fa-spin' : 'fa-sync-alt']"
               aria-hidden="true"
             ></i>
             {{ publishing ? t('profile.mcp.publishing') : t('profile.mcp.publishData') }}
           </button>
 
-          <div v-if="lastSyncTime" class="text-sm text-gray-600">
-            <i class="fas fa-check-circle text-green-600 mr-1" aria-hidden="true"></i>
-            {{ t('profile.mcp.lastSync') }}: {{ formatDate(lastSyncTime) }}
-          </div>
+          <p v-if="lastSyncTime" class="field-hint">
+            <i class="fas fa-check" aria-hidden="true"></i>
+            {{ t('profile.mcp.lastSync') }} : {{ formatDate(lastSyncTime) }}
+          </p>
         </div>
-      </div>
+      </section>
 
-      <!-- Step 2: Copy Manifest URL -->
-      <div v-if="manifestUrl" class="bg-white shadow p-6">
-        <div class="flex items-start gap-3 mb-4">
-          <div
-            class="flex-shrink-0 w-8 h-8 bg-green-600 text-white rounded-full flex items-center justify-center font-bold"
-          >
-            2
-          </div>
-          <div class="flex-1">
-            <h3 class="text-lg font-semibold text-gray-900">
-              {{ t('profile.mcp.step2Title') }}
-            </h3>
-            <p class="text-sm text-gray-600 mt-1">{{ t('profile.mcp.step2Help') }}</p>
-          </div>
-        </div>
+      <section v-if="manifestUrl">
+        <h3><span class="step">2</span>{{ t('profile.mcp.step2Title') }}</h3>
+        <p class="panel-lead">{{ t('profile.mcp.step2Help') }}</p>
 
-        <div class="flex gap-2">
-          <input
-            ref="urlInput"
-            :value="manifestUrl"
-            readonly
-            @click="selectAll"
-            class="flex-1 px-3 py-2 bg-gray-50 border border-gray-300 rounded-md text-sm font-mono text-gray-700 focus:outline-none focus:ring-2 focus:ring-green-500"
-          />
+        <div class="card url-card">
+          <input ref="urlInput" :value="manifestUrl" readonly @click="selectAll" class="url" />
           <button
             @click="copyToClipboard"
-            :class="[
-              'px-4 py-2 rounded-md font-medium text-sm transition-colors',
-              copied ? 'bg-green-600 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
-            ]"
+            class="btn"
+            :class="copied ? 'btn--primary' : 'btn--quiet'"
           >
-            <i :class="['fas', copied ? 'fa-check' : 'fa-copy', 'mr-2']" aria-hidden="true"></i>
+            <i :class="['fas', copied ? 'fa-check' : 'fa-copy']" aria-hidden="true"></i>
             {{ copied ? t('profile.mcp.copied') : t('profile.mcp.copy') }}
           </button>
         </div>
-      </div>
+      </section>
 
-      <!-- Step 3: Configure MCP Client -->
-      <div class="bg-white shadow p-6">
-        <div class="flex items-start gap-3 mb-4">
-          <div
-            class="flex-shrink-0 w-8 h-8 bg-green-600 text-white rounded-full flex items-center justify-center font-bold"
-          >
-            3
-          </div>
-          <div class="flex-1">
-            <h3 class="text-lg font-semibold text-gray-900">
-              {{ t('profile.mcp.step3Title') }}
-            </h3>
-          </div>
-        </div>
+      <section>
+        <h3><span class="step">3</span>{{ t('profile.mcp.step3Title') }}</h3>
 
-        <details class="group">
-          <summary
-            class="flex items-center gap-2 cursor-pointer text-green-600 hover:text-green-700 font-medium mb-4"
-          >
+        <details class="card config">
+          <summary class="config__summary">
             <i class="fas fa-book" aria-hidden="true"></i>
             {{ t('profile.mcp.showConfig') }}
-            <i
-              class="fas fa-chevron-down group-open:rotate-180 transition-transform ml-auto"
-              aria-hidden="true"
-            ></i>
+            <i class="fas fa-chevron-down config__chevron" aria-hidden="true"></i>
           </summary>
 
-          <div class="space-y-4 pt-2">
-            <p class="text-sm text-gray-600">{{ t('profile.mcp.configIntro') }}</p>
+          <p class="field-hint">{{ t('profile.mcp.configIntro') }}</p>
 
-            <!-- Platform tabs -->
-            <div class="flex gap-2 border-b border-gray-200">
-              <button
-                v-for="platform in platforms"
-                :key="platform.id"
-                @click="selectedPlatform = platform.id"
-                :class="[
-                  'px-4 py-2 text-sm font-medium border-b-2 transition-colors',
-                  selectedPlatform === platform.id
-                    ? 'border-green-600 text-green-600'
-                    : 'border-transparent text-gray-600 hover:text-gray-900'
-                ]"
-              >
-                {{ platform.name }}
+          <div class="platforms" role="tablist">
+            <button
+              v-for="platform in platforms"
+              :key="platform.id"
+              role="tab"
+              :aria-selected="selectedPlatform === platform.id"
+              :class="['platform', { active: selectedPlatform === platform.id }]"
+              @click="selectedPlatform = platform.id"
+            >
+              {{ platform.name }}
+            </button>
+          </div>
+
+          <div class="code">
+            <div class="code__head">
+              <span class="code__path">
+                <i class="fas fa-file-code" aria-hidden="true"></i>
+                {{ currentPlatformPath }}
+              </span>
+              <button @click="copyConfig" class="code__copy">
+                <i class="fas fa-copy" aria-hidden="true"></i>
+                {{ t('profile.mcp.copyConfig') }}
               </button>
             </div>
-
-            <!-- Config code -->
-            <div class="relative">
-              <div
-                class="flex items-center justify-between px-3 py-2 bg-gray-800 text-gray-300 text-xs rounded-t-md"
-              >
-                <span class="flex items-center gap-2">
-                  <i class="fas fa-file-code" aria-hidden="true"></i>
-                  {{ currentPlatformPath }}
-                </span>
-                <button
-                  @click="copyConfig"
-                  class="px-2 py-1 bg-gray-700 hover:bg-gray-600 rounded text-white"
-                >
-                  <i class="fas fa-copy mr-1" aria-hidden="true"></i>
-                  {{ t('profile.mcp.copyConfig') }}
-                </button>
-              </div>
-              <pre
-                class="p-4 bg-gray-900 text-gray-100 text-xs rounded-b-md overflow-x-auto"
-              ><code>{{ configCode }}</code></pre>
-            </div>
-
-            <!-- Instructions -->
-            <ol class="space-y-2 text-sm text-gray-600 list-decimal list-inside">
-              <li>{{ t('profile.mcp.configStep1') }}</li>
-              <li>{{ t('profile.mcp.configStep2') }}</li>
-              <li>{{ t('profile.mcp.configStep3') }}</li>
-            </ol>
+            <pre class="code__body"><code>{{ configCode }}</code></pre>
           </div>
+
+          <ol class="steps">
+            <li>{{ t('profile.mcp.configStep1') }}</li>
+            <li>{{ t('profile.mcp.configStep2') }}</li>
+            <li>{{ t('profile.mcp.configStep3') }}</li>
+          </ol>
         </details>
-      </div>
+      </section>
 
-      <!-- Statistics -->
-      <div v-if="stats" class="bg-white shadow p-6">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-          <i class="fas fa-chart-bar text-green-600" aria-hidden="true"></i>
-          {{ t('profile.mcp.statsTitle') }}
-        </h3>
-
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div class="bg-gray-50 rounded-lg p-4 text-center">
-            <div class="text-3xl font-bold text-green-600">{{ stats.totalActivities }}</div>
-            <div class="text-sm text-gray-600 mt-1">{{ t('profile.mcp.totalActivities') }}</div>
+      <section v-if="stats">
+        <h3>{{ t('profile.mcp.statsTitle') }}</h3>
+        <div class="stats">
+          <div class="stat">
+            <span class="stat__value">{{ stats.totalActivities }}</span>
+            <span class="stat__label">{{ t('profile.mcp.totalActivities') }}</span>
           </div>
-          <div class="bg-gray-50 rounded-lg p-4 text-center">
-            <div class="text-3xl font-bold text-green-600">
-              {{ formatDistance(stats.totalDistance) }}
-            </div>
-            <div class="text-sm text-gray-600 mt-1">{{ t('profile.mcp.totalDistance') }}</div>
+          <div class="stat">
+            <span class="stat__value">{{ formatDistance(stats.totalDistance) }}</span>
+            <span class="stat__label">{{ t('profile.mcp.totalDistance') }}</span>
           </div>
-          <div class="bg-gray-50 rounded-lg p-4 text-center">
-            <div class="text-3xl font-bold text-green-600">
-              {{ formatDuration(stats.totalDuration) }}
-            </div>
-            <div class="text-sm text-gray-600 mt-1">{{ t('profile.mcp.totalDuration') }}</div>
+          <div class="stat">
+            <span class="stat__value">{{ formatDuration(stats.totalDuration) }}</span>
+            <span class="stat__label">{{ t('profile.mcp.totalDuration') }}</span>
           </div>
         </div>
-      </div>
-    </div>
+      </section>
+    </template>
   </div>
 </template>
 
@@ -395,3 +311,214 @@ function formatDuration(seconds: number): string {
   return `${minutes}min`
 }
 </script>
+
+<style scoped>
+/* Layout, cards, notices and buttons come from profile.css. */
+.step {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--color-green-600);
+  color: var(--color-white);
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+}
+
+.notice {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  background: var(--color-yellow-50);
+  border: 1px solid var(--color-yellow-200);
+  border-radius: var(--radius-md);
+}
+
+.notice__title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-yellow-800);
+}
+
+.notice__text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--color-yellow-800);
+}
+
+.btn--notice {
+  align-self: flex-start;
+  background: var(--color-yellow-500);
+  color: var(--color-white);
+}
+
+.btn--notice:hover {
+  background: var(--color-yellow-600);
+}
+
+.url-card {
+  flex-direction: row;
+  align-items: center;
+}
+
+.url {
+  flex: 1;
+  min-width: 0;
+  padding: 0.5rem 0.625rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+}
+
+/* ===== Config ===== */
+.config__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-green-700);
+  list-style: none;
+}
+
+.config__chevron {
+  margin-left: auto;
+  transition: transform 0.2s;
+}
+
+.config[open] .config__chevron {
+  transform: rotate(180deg);
+}
+
+.platforms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.platform {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: none;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.platform.active {
+  border-bottom-color: var(--color-green-600);
+  color: var(--color-green-700);
+}
+
+.code {
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.code__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-ink);
+  color: var(--color-gray-300);
+  font-size: 0.75rem;
+}
+
+.code__path {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.code__copy {
+  flex-shrink: 0;
+  padding: 0.25rem 0.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.14);
+  color: var(--color-white);
+  font-family: inherit;
+  font-size: 0.6875rem;
+  cursor: pointer;
+}
+
+.code__copy:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.code__body {
+  margin: 0;
+  padding: 0.875rem;
+  background: #14141f;
+  color: var(--color-gray-100);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+.steps {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+/* ===== Stats ===== */
+.stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+  gap: 0.5rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.875rem 0.5rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+  text-align: center;
+}
+
+.stat__value {
+  font-family: var(--font-mono);
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: var(--color-green-700);
+}
+
+.stat__label {
+  font-size: 0.75rem;
+  line-height: 1.35;
+  color: var(--text-muted);
+}
+</style>

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -1,6 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800&family=Barlow:wght@400;500;600;700&family=Barlow+Condensed:wght@500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap');
 @import '@fortawesome/fontawesome-free/css/all.min.css';
 @import './variables.css';
+@import './profile.css';
 @import 'tailwindcss';
 
 html {

--- a/src/assets/styles/profile.css
+++ b/src/assets/styles/profile.css
@@ -1,0 +1,212 @@
+/**
+ * The shared vocabulary of a profile tab.
+ *
+ * Six panels used to carry six copies of "a card", "a section title" and "a
+ * button", and they had drifted: square cards next to rounded ones, three
+ * heading sizes, buttons that were green here and outlined there. Defining
+ * them once is the only way the tabs stay in agreement.
+ *
+ * Everything is namespaced under `.profile-panel`, so nothing leaks out of the
+ * profile — these are panel primitives, not an app-wide design system.
+ */
+
+.profile-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+/* A group of related settings. No panel carries a title of its own: the tab
+   strip sitting directly above already names it, and repeating it produced
+   three headings for one list. */
+.profile-panel section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-panel h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.profile-panel .panel-lead {
+  margin: -0.25rem 0 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+/* ===== Cards ===== */
+
+.profile-panel .card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+/* A card whose whole content is one row: an item and what you can do to it. */
+.profile-panel .row-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.profile-panel .row-card__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  object-fit: contain;
+}
+
+.profile-panel .row-card__label {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+/* ===== Lists ===== */
+
+.profile-panel .stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* ===== Empty states ===== */
+
+.profile-panel .panel-empty {
+  margin: 0;
+  padding: 1rem;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  color: var(--text-muted);
+}
+
+/* ===== Fields ===== */
+
+.profile-panel .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-panel .field > label,
+.profile-panel .field-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.profile-panel .field-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--text-faint);
+}
+
+.profile-panel input[type='text'],
+.profile-panel input[type='number'],
+.profile-panel select {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.9375rem;
+  color: var(--color-ink);
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+}
+
+.profile-panel input[type='text']:focus,
+.profile-panel input[type='number']:focus,
+.profile-panel select:focus {
+  outline: 2px solid var(--color-green-400);
+  outline-offset: 1px;
+}
+
+/* ===== Buttons =====
+   One shape, three weights: filled for the act the panel exists for, quiet for
+   everything else, and outlined for a per-item action inside a list. */
+
+.profile-panel .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    border-color 0.2s,
+    color 0.2s;
+}
+
+.profile-panel .btn--block {
+  width: 100%;
+}
+
+.profile-panel .btn--primary {
+  background: var(--color-green-600);
+  color: var(--color-white);
+}
+
+.profile-panel .btn--primary:hover:not(:disabled) {
+  background: var(--color-green-700);
+}
+
+.profile-panel .btn--quiet {
+  background: var(--surface);
+  border-color: var(--border-subtle);
+  color: var(--color-ink);
+}
+
+.profile-panel .btn--quiet:hover:not(:disabled) {
+  background: var(--surface-2);
+}
+
+.profile-panel .btn--outline {
+  background: transparent;
+  border-color: var(--color-green-600);
+  color: var(--color-green-700);
+}
+
+.profile-panel .btn--outline:hover {
+  background: var(--color-green-600);
+  color: var(--color-white);
+}
+
+.profile-panel .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/LanguageSelector.vue
+++ b/src/components/LanguageSelector.vue
@@ -1,13 +1,11 @@
 <template>
-  <div class="language-selector">
-    <label for="language-select" class="text-sm font-medium text-gray-700">
-      {{ t('languages.label') }}
-    </label>
+  <!-- `field` and the input styling come from profile.css, where this renders. -->
+  <div class="language-selector field">
+    <label for="language-select">{{ t('languages.label') }}</label>
     <select
       id="language-select"
       v-model="currentLocale"
       @change="onLocaleChange"
-      class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 focus:border-green-500 text-sm"
       :aria-label="t('languages.label')"
     >
       <option value="en">{{ t('languages.en') }}</option>

--- a/src/components/profile/ProfileAppExtensions.vue
+++ b/src/components/profile/ProfileAppExtensions.vue
@@ -1,62 +1,37 @@
 <template>
-  <div class="space-y-6">
-    <h2 class="text-2xl font-bold">{{ t('appExtensions.title', 'App Extensions') }}</h2>
-    <p class="text-gray-600">
-      {{
-        t('appExtensions.description', 'Manage widgets and features displayed throughout the app')
-      }}
-    </p>
-
-    <!-- Extensions List -->
+  <div class="profile-panel">
     <section>
-      <ul v-if="!loading" class="space-y-3">
-        <li
-          v-for="plugin in allPlugins"
-          :key="plugin.id"
-          class="flex items-center justify-between bg-white p-4 rounded-lg shadow hover:shadow-md transition"
-        >
-          <div class="flex items-center space-x-4 flex-1">
-            <!-- Icon -->
-            <i
-              v-if="plugin.icon"
-              :class="plugin.icon"
-              class="text-2xl text-gray-700"
-              aria-hidden="true"
-            ></i>
-            <i v-else class="fas fa-puzzle-piece text-2xl text-gray-400" aria-hidden="true"></i>
+      <h3>{{ t('appExtensions.title') }}</h3>
+      <p class="panel-lead">{{ t('appExtensions.description') }}</p>
 
-            <!-- Label & Description -->
-            <div class="flex-1">
-              <div class="font-semibold text-gray-900">{{ plugin.label }}</div>
-              <div v-if="plugin.description" class="text-sm text-gray-600 mt-1">
-                {{ plugin.description }}
-              </div>
-            </div>
+      <ul v-if="!loading" class="stack">
+        <li v-for="plugin in allPlugins" :key="plugin.id" class="ext">
+          <i :class="plugin.icon || 'fas fa-puzzle-piece'" class="ext__icon" aria-hidden="true"></i>
+
+          <div class="ext__text">
+            <span class="ext__label">{{ labelOf(plugin) }}</span>
+            <span v-if="descriptionOf(plugin)" class="ext__desc">{{ descriptionOf(plugin) }}</span>
           </div>
 
-          <!-- Toggle Switch -->
-          <label class="relative inline-flex items-center cursor-pointer">
+          <label class="switch">
             <input
               type="checkbox"
               :checked="enabledPluginIds.includes(plugin.id)"
               @change="handleToggle(plugin.id)"
               :disabled="isToggling"
-              class="sr-only peer"
               role="switch"
               :aria-checked="enabledPluginIds.includes(plugin.id)"
-              :aria-label="`Toggle ${plugin.label}`"
+              :aria-label="t('appExtensions.toggle', { name: labelOf(plugin) })"
             />
-            <div
-              class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-green-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600 peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"
-            ></div>
+            <span class="switch__track" aria-hidden="true"></span>
           </label>
         </li>
       </ul>
 
-      <div v-else class="text-center text-gray-500 py-8 bg-gray-50 rounded-lg">
-        <i class="fas fa-spinner fa-spin text-2xl mb-2" aria-hidden="true"></i>
-        <p>{{ t('common.loading') }}</p>
-      </div>
+      <p v-else class="panel-empty">
+        <i class="fas fa-spinner fa-spin" aria-hidden="true"></i>
+        {{ t('common.loading') }}
+      </p>
     </section>
   </div>
 </template>
@@ -68,7 +43,23 @@ import { allAppPlugins } from '@/services/ExtensionPluginRegistry'
 import type { ExtensionPlugin } from '@/types/extension'
 import { AppExtensionPluginManager } from '@/services/AppExtensionPluginManager'
 
-const { t } = useI18n()
+const { t, te } = useI18n()
+
+/**
+ * An extension's user-facing name comes from the locale, keyed by its id.
+ *
+ * Nine plugins declared an English `label` and `description` in their
+ * `index.ts`, and the tab showed all nine in English to a French reader —
+ * the mirror of the hardcoded French toasts the contracts test now guards.
+ * Indexing on the id keeps the translations in the locale files, where a
+ * translator can reach them, and leaves the declared string as the fallback
+ * for a plugin nobody has translated yet.
+ */
+const labelOf = (p: ExtensionPlugin) =>
+  te(`extensions.${p.id}.label`) ? t(`extensions.${p.id}.label`) : p.label
+
+const descriptionOf = (p: ExtensionPlugin) =>
+  te(`extensions.${p.id}.description`) ? t(`extensions.${p.id}.description`) : p.description
 
 const manager = AppExtensionPluginManager.getInstance()
 const allPlugins = ref<ExtensionPlugin[]>(allAppPlugins)
@@ -104,3 +95,103 @@ async function handleToggle(pluginId: string) {
   }
 }
 </script>
+
+<style scoped>
+.ext {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.875rem 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-card);
+}
+
+.ext__icon {
+  width: 1.5rem;
+  flex-shrink: 0;
+  text-align: center;
+  font-size: 1.125rem;
+  color: var(--color-green-600);
+}
+
+/* The description used to run under the toggle, which floated on top of it. */
+.ext__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.ext__label {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-ink);
+}
+
+.ext__desc {
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+/* ===== Switch ===== */
+.switch {
+  position: relative;
+  flex-shrink: 0;
+  width: 2.75rem;
+  height: 1.5rem;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+
+.switch__track {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--color-gray-300);
+  transition: background 0.2s;
+}
+
+.switch__track::after {
+  content: '';
+  position: absolute;
+  top: 0.125rem;
+  left: 0.125rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: var(--color-white);
+  box-shadow: 0 1px 2px rgba(30, 30, 46, 0.25);
+  transition: transform 0.2s;
+}
+
+.switch input:checked + .switch__track {
+  background: var(--color-green-600);
+}
+
+.switch input:checked + .switch__track::after {
+  transform: translateX(1.25rem);
+}
+
+.switch input:focus-visible + .switch__track {
+  outline: 2px solid var(--color-green-400);
+  outline-offset: 2px;
+}
+
+.switch input:disabled + .switch__track {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/profile/ProfileAthlete.vue
+++ b/src/components/profile/ProfileAthlete.vue
@@ -1,151 +1,129 @@
 <template>
-  <div class="space-y-6">
-    <h2 class="text-2xl font-bold">{{ t('profile.athlete.title') }}</h2>
+  <div class="profile-panel">
+    <section>
+      <h3>{{ t('profile.identity.section') }}</h3>
 
-    <!-- Section Identité (nom + photo) -->
-    <div class="bg-white shadow p-6 space-y-4">
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">{{ t('profile.identity.section') }}</h3>
+      <div class="card">
+        <!-- Mode édition -->
+        <template v-if="!isProfileSaved">
+          <div class="field">
+            <label for="username">{{ t('profile.enterUsername') }}</label>
+            <input
+              id="username"
+              v-model="username"
+              type="text"
+              :placeholder="t('profile.enterUsername')"
+            />
+          </div>
 
-      <!-- Mode édition -->
-      <div v-if="!isProfileSaved" class="space-y-4">
-        <div>
-          <label for="username" class="block text-sm font-medium text-gray-700 mb-1">
-            {{ t('profile.enterUsername') }}
-          </label>
-          <input
-            id="username"
-            v-model="username"
-            :placeholder="t('profile.enterUsername')"
-            class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-          />
-        </div>
+          <div class="field">
+            <label for="file-upload" class="dropzone">
+              <i class="fas fa-camera" aria-hidden="true"></i>
+              {{ t('profile.choosePhoto') }}
+            </label>
+            <input
+              type="file"
+              id="file-upload"
+              class="visually-hidden"
+              capture="user"
+              accept="image/*"
+              @change="onFileChange"
+            />
+          </div>
 
-        <div>
-          <label
-            for="file-upload"
-            class="block w-full text-center py-2 border border-dashed border-gray-400 rounded-md cursor-pointer hover:bg-gray-50"
-          >
-            {{ t('profile.choosePhoto') }}
-          </label>
-          <input
-            type="file"
-            id="file-upload"
-            class="hidden"
-            capture="user"
-            accept="image/*"
-            @change="onFileChange"
-          />
-        </div>
-
-        <div v-if="photoPreview" class="flex justify-center">
           <img
+            v-if="photoPreview"
             :src="photoPreview"
             :alt="t('profile.profilePhoto')"
-            class="w-24 h-24 rounded-full object-cover border"
+            class="avatar"
+          />
+
+          <button @click="saveProfile" class="btn btn--primary btn--block">
+            {{ t('common.save') }}
+          </button>
+        </template>
+
+        <!-- Mode affichage -->
+        <template v-else>
+          <div class="identity">
+            <img
+              v-if="savedProfile.photo"
+              :src="savedProfile.photo"
+              :alt="t('profile.profilePhoto')"
+              class="avatar"
+            />
+            <p class="identity__name">{{ savedProfile.username }}</p>
+            <button @click="editProfile" class="btn btn--quiet">
+              <i class="fas fa-pen" aria-hidden="true"></i>
+              {{ t('profile.editProfile') }}
+            </button>
+          </div>
+        </template>
+      </div>
+    </section>
+
+    <section>
+      <h3>{{ t('profile.athlete.section') }}</h3>
+      <p class="panel-lead">{{ t('profile.athlete.lead') }}</p>
+
+      <div class="card">
+        <div class="field">
+          <label for="weight">{{ t('profile.athlete.weight') }}</label>
+          <input
+            id="weight"
+            v-model.number="athleteData.weight"
+            type="number"
+            min="0"
+            step="0.1"
+            placeholder="70.0"
           />
         </div>
 
-        <button
-          @click="saveProfile"
-          class="w-full bg-green-600 text-white py-2 rounded-md hover:bg-green-700"
-        >
+        <div class="field">
+          <label for="maxHR">{{ t('profile.athlete.maxHR') }}</label>
+          <input
+            id="maxHR"
+            v-model.number="athleteData.maxHR"
+            type="number"
+            min="0"
+            max="250"
+            placeholder="190"
+          />
+        </div>
+
+        <div class="field">
+          <label for="restingHR">{{ t('profile.athlete.restingHR') }}</label>
+          <input
+            id="restingHR"
+            v-model.number="athleteData.restingHR"
+            type="number"
+            min="0"
+            max="150"
+            placeholder="60"
+          />
+        </div>
+
+        <div class="field">
+          <label for="ftp">{{ t('profile.athlete.ftp') }}</label>
+          <input
+            id="ftp"
+            v-model.number="athleteData.ftp"
+            type="number"
+            min="0"
+            placeholder="250"
+          />
+        </div>
+
+        <button @click="saveAthleteProfile" class="btn btn--primary btn--block">
           {{ t('common.save') }}
         </button>
+
+        <p v-if="saveSuccess" class="saved" role="status">
+          <i class="fas fa-check" aria-hidden="true"></i>
+          {{ t('profile.athlete.saveSuccess') }}
+        </p>
       </div>
-
-      <!-- Mode affichage -->
-      <div v-else class="text-center space-y-4">
-        <div class="flex justify-center">
-          <img
-            v-if="savedProfile.photo"
-            :src="savedProfile.photo"
-            :alt="t('profile.profilePhoto')"
-            class="w-24 h-24 rounded-full object-cover border-2 border-gray-300"
-          />
-        </div>
-
-        <p class="text-lg font-semibold">{{ savedProfile.username }}</p>
-
-        <button @click="editProfile" class="bg-gray-200 hover:bg-gray-300 px-4 py-2 rounded-md">
-          {{ t('profile.editProfile') }}
-        </button>
-      </div>
-    </div>
-
-    <!-- Section Informations Athlète -->
-    <div class="bg-white shadow p-6 space-y-4">
-      <h3 class="text-lg font-semibold text-gray-700 mb-3">{{ t('profile.athlete.section') }}</h3>
-
-      <div>
-        <label for="weight" class="block text-sm font-medium text-gray-700 mb-1">
-          {{ t('profile.athlete.weight') }}
-        </label>
-        <input
-          id="weight"
-          v-model.number="athleteData.weight"
-          type="number"
-          min="0"
-          step="0.1"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-          placeholder="70.0"
-        />
-      </div>
-
-      <div>
-        <label for="maxHR" class="block text-sm font-medium text-gray-700 mb-1">
-          {{ t('profile.athlete.maxHR') }}
-        </label>
-        <input
-          id="maxHR"
-          v-model.number="athleteData.maxHR"
-          type="number"
-          min="0"
-          max="250"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-          placeholder="190"
-        />
-      </div>
-
-      <div>
-        <label for="restingHR" class="block text-sm font-medium text-gray-700 mb-1">
-          {{ t('profile.athlete.restingHR') }}
-        </label>
-        <input
-          id="restingHR"
-          v-model.number="athleteData.restingHR"
-          type="number"
-          min="0"
-          max="150"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-          placeholder="60"
-        />
-      </div>
-
-      <div>
-        <label for="ftp" class="block text-sm font-medium text-gray-700 mb-1">
-          {{ t('profile.athlete.ftp') }}
-        </label>
-        <input
-          id="ftp"
-          v-model.number="athleteData.ftp"
-          type="number"
-          min="0"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-          placeholder="250"
-        />
-      </div>
-
-      <button
-        @click="saveAthleteProfile"
-        class="w-full bg-green-600 text-white py-2 rounded-md hover:bg-green-700"
-      >
-        {{ t('common.save') }}
-      </button>
-
-      <div v-if="saveSuccess" class="text-green-600 text-sm text-center">
-        {{ t('profile.athlete.saveSuccess') }}
-      </div>
-    </div>
+    </section>
   </div>
 </template>
 
@@ -263,3 +241,70 @@ const saveAthleteProfile = async () => {
   }, 3000)
 }
 </script>
+
+<style scoped>
+.dropzone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.875rem;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.dropzone:hover {
+  border-color: var(--color-green-400);
+  color: var(--color-ink);
+}
+
+/* `display: none` on a file input makes it unreachable by keyboard, and the
+   label is the only way in. This hides it without removing it from the tree. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.avatar {
+  align-self: center;
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--border-subtle);
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.identity__name {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+.saved {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-green-700);
+}
+</style>

--- a/src/components/profile/ProfileCloudBackup.vue
+++ b/src/components/profile/ProfileCloudBackup.vue
@@ -1,53 +1,29 @@
 <template>
-  <div class="space-y-6">
-    <h2 class="text-2xl font-bold">{{ t('storageProviders.title') }}</h2>
-
-    <!-- Connected Storage Plugins -->
+  <!-- Structurally the twin of the data-sources panel, and now literally so:
+       same markup, same primitives, same words for the same acts. -->
+  <div class="profile-panel">
     <section>
-      <h3 class="text-lg font-semibold mb-3">
-        {{ t('storageProviders.myPlugins', 'My Cloud Backups') }}
-      </h3>
-      <ul v-if="userStoragePlugins.length" class="space-y-3">
-        <li
-          v-for="plugin in userStoragePlugins"
-          :key="plugin.id"
-          class="flex items-center justify-between bg-white p-4 rounded-lg shadow hover:shadow-md transition"
-        >
-          <div class="flex items-center space-x-3">
-            <img :src="plugin.icon" :alt="t('app.providerLogo')" class="w-6 h-6" />
-            <span class="font-semibold">{{ plugin.label }}</span>
-          </div>
-          <router-link
-            :to="`/storage-provider/${plugin.id}`"
-            class="inline-flex items-center gap-2 px-4 py-1.5 border border-green-600 text-green-600 rounded-md text-sm font-medium hover:bg-green-600 hover:text-white transition-colors duration-200"
-          >
+      <h3>{{ t('storageProviders.myPlugins') }}</h3>
+      <ul v-if="userStoragePlugins.length" class="stack">
+        <li v-for="plugin in userStoragePlugins" :key="plugin.id" class="row-card">
+          <img :src="plugin.icon" :alt="t('app.providerLogo')" class="row-card__icon" />
+          <span class="row-card__label">{{ plugin.label }}</span>
+          <router-link :to="`/storage-provider/${plugin.id}`" class="btn btn--outline">
             <i class="fas fa-cog" aria-hidden="true"></i>
             {{ t('common.configure') }}
           </router-link>
         </li>
       </ul>
-      <p v-else class="text-gray-500 bg-gray-50 p-4 rounded-lg border border-gray-200">
-        {{ t('storageProviders.noPlugins') }}
-      </p>
+      <p v-else class="panel-empty">{{ t('storageProviders.noPlugins') }}</p>
     </section>
 
-    <!-- Available Storage Plugins -->
     <section>
-      <h3 class="text-lg font-semibold mb-3">{{ t('storageProviders.available') }}</h3>
-      <ul class="space-y-3">
-        <li
-          v-for="plugin in availableBackups"
-          :key="plugin.id"
-          class="flex items-center justify-between bg-gray-50 p-4 rounded-lg border border-gray-200"
-        >
-          <div class="flex items-center space-x-3">
-            <img :src="plugin.icon" :alt="t('app.providerLogo')" class="w-6 h-6" />
-            <span>{{ plugin.label }}</span>
-          </div>
-          <button
-            @click="installBackup(plugin.id)"
-            class="bg-green-600 text-white px-3 py-1.5 rounded-md hover:bg-green-700 text-sm font-medium"
-          >
+      <h3>{{ t('storageProviders.available') }}</h3>
+      <ul class="stack">
+        <li v-for="plugin in availableBackups" :key="plugin.id" class="row-card">
+          <img :src="plugin.icon" :alt="t('app.providerLogo')" class="row-card__icon" />
+          <span class="row-card__label">{{ plugin.label }}</span>
+          <button @click="installBackup(plugin.id)" class="btn btn--primary">
             {{ t('common.add') }}
           </button>
         </li>

--- a/src/components/profile/ProfileDataSources.vue
+++ b/src/components/profile/ProfileDataSources.vue
@@ -1,64 +1,51 @@
 <template>
-  <div class="space-y-6">
-    <InstallPrompt variant="gate" class="mb-6" />
+  <!-- No <h2> here: the tab strip a few pixels above already says "Data
+       sources", and the panel repeating it produced three headings for one
+       list. The panel is labelled by its tab through aria-labelledby. -->
+  <div class="profile-panel">
+    <InstallPrompt variant="gate" />
 
-    <h2 class="text-2xl font-bold">{{ t('dataProviders.title') }}</h2>
-
-    <!-- Connected Providers -->
     <section data-test="connected-providers-section">
-      <h3 class="text-lg font-semibold mb-3" data-test="connected-providers-title">
-        {{ t('dataProviders.myProviders', 'My Data Sources') }}
-      </h3>
-      <ul v-if="userProviders.length" class="space-y-3" data-test="connected-providers-list">
+      <h3 data-test="connected-providers-title">{{ t('dataProviders.myProviders') }}</h3>
+      <ul v-if="userProviders.length" class="stack" data-test="connected-providers-list">
         <li
           v-for="provider in userProviders"
           :key="provider.id"
           :data-test="`connected-provider-${provider.id}`"
-          class="flex items-center justify-between bg-white p-4 rounded-lg shadow hover:shadow-md transition"
+          class="row-card"
         >
-          <div class="flex items-center space-x-3">
-            <img :src="provider.icon" :alt="t('app.providerLogo')" class="w-6 h-6" />
-            <span class="font-semibold">{{ provider.label }}</span>
-          </div>
+          <img :src="provider.icon" :alt="t('app.providerLogo')" class="row-card__icon" />
+          <span class="row-card__label">{{ provider.label }}</span>
           <router-link
             :to="`/data-provider/${provider.id}`"
             :data-test="`configure-provider-${provider.id}`"
-            class="inline-flex items-center gap-2 px-4 py-1.5 border border-green-600 text-green-600 rounded-md text-sm font-medium hover:bg-green-600 hover:text-white transition-colors duration-200"
+            class="btn btn--outline"
           >
             <i class="fas fa-cog" aria-hidden="true"></i>
             {{ t('common.configure') }}
           </router-link>
         </li>
       </ul>
-      <p
-        v-else
-        class="text-gray-500 bg-gray-50 p-4 rounded-lg border border-gray-200"
-        data-test="no-providers-message"
-      >
+      <p v-else class="panel-empty" data-test="no-providers-message">
         {{ t('dataProviders.noProviders') }}
       </p>
     </section>
 
-    <!-- Available Providers -->
     <section data-test="available-providers-section">
-      <h3 class="text-lg font-semibold mb-3" data-test="available-providers-title">
-        {{ t('dataProviders.available') }}
-      </h3>
-      <ul class="space-y-3" data-test="available-providers-list">
+      <h3 data-test="available-providers-title">{{ t('dataProviders.available') }}</h3>
+      <ul class="stack" data-test="available-providers-list">
         <li
           v-for="provider in availableProviders"
           :key="provider.id"
           :data-test="`available-provider-${provider.id}`"
-          class="flex items-center justify-between bg-gray-50 p-4 rounded-lg border border-gray-200"
+          class="row-card"
         >
-          <div class="flex items-center space-x-3">
-            <img :src="provider.icon" :alt="t('app.providerLogo')" class="w-6 h-6" />
-            <span>{{ provider.label }}</span>
-          </div>
+          <img :src="provider.icon" :alt="t('app.providerLogo')" class="row-card__icon" />
+          <span class="row-card__label">{{ provider.label }}</span>
           <button
             @click="installProvider(provider.id)"
             :data-test="`add-provider-${provider.id}`"
-            class="bg-green-600 text-white px-3 py-1.5 rounded-md hover:bg-green-700 text-sm font-medium"
+            class="btn btn--primary"
           >
             {{ t('common.add') }}
           </button>

--- a/src/components/profile/ProfileFriends.vue
+++ b/src/components/profile/ProfileFriends.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="profile-friends">
+  <div class="profile-panel profile-friends">
     <!-- "Being followed" belongs with "following": the sharing plugin renders
          your own profile and QR code here -->
     <component
@@ -289,14 +289,8 @@ const formatRelativeTime = (timestamp: number): string => {
 </script>
 
 <style scoped>
-.profile-friends {
-  max-width: 800px;
-  margin: 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-}
-
+/* Layout, cards and buttons come from profile.css — this file keeps only what
+   is specific to a friend row. */
 .friends-block {
   display: flex;
   flex-direction: column;
@@ -331,44 +325,6 @@ const formatRelativeTime = (timestamp: number): string => {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.625rem 1rem;
-  border: none;
-  border-radius: var(--radius-md);
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-
-.btn--primary {
-  background: var(--color-green-600);
-  color: var(--color-white);
-}
-
-.btn--primary:hover {
-  background: var(--color-green-700);
-}
-
-.btn--quiet {
-  background: var(--surface);
-  border: 1px solid var(--border-subtle);
-  color: var(--color-ink);
-}
-
-.btn--quiet:hover:not(:disabled) {
-  background: var(--surface-2);
-}
-
-.btn--quiet:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .spinning {

--- a/src/components/profile/ProfilePreferences.vue
+++ b/src/components/profile/ProfilePreferences.vue
@@ -1,85 +1,45 @@
 <template>
-  <div class="space-y-6">
-    <h2 class="text-2xl font-bold">{{ t('profile.preferences.title') }}</h2>
-
-    <div class="bg-white shadow p-6 space-y-4">
-      <!-- Language Selector -->
-      <div>
+  <div class="profile-panel">
+    <!-- No heading: a section title tells two sections apart, and this panel
+         has one. The tab strip above already says "Preferences". -->
+    <section>
+      <div class="card">
         <LanguageSelector />
+
+        <fieldset class="field units">
+          <legend class="field-label">{{ t('profile.preferences.units') }}</legend>
+          <div class="units__choices">
+            <label class="choice">
+              <input
+                type="radio"
+                v-model="preferences.units"
+                value="metric"
+                data-test="units-metric"
+              />
+              <span>{{ t('profile.preferences.metric') }}</span>
+            </label>
+            <label class="choice">
+              <input
+                type="radio"
+                v-model="preferences.units"
+                value="imperial"
+                data-test="units-imperial"
+              />
+              <span>{{ t('profile.preferences.imperial') }}</span>
+            </label>
+          </div>
+        </fieldset>
+
+        <button @click="savePreferences" class="btn btn--primary btn--block">
+          {{ t('common.save') }}
+        </button>
+
+        <p v-if="saveSuccess" class="saved" role="status">
+          <i class="fas fa-check" aria-hidden="true"></i>
+          {{ t('profile.preferences.saveSuccess') }}
+        </p>
       </div>
-
-      <!-- Unit System -->
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">
-          {{ t('profile.preferences.units') }}
-        </label>
-        <div class="flex gap-4">
-          <label class="flex items-center cursor-pointer">
-            <input
-              type="radio"
-              v-model="preferences.units"
-              value="metric"
-              data-test="units-metric"
-              class="mr-2 text-green-600 focus:ring-green-500"
-            />
-            <span>{{ t('profile.preferences.metric') }}</span>
-          </label>
-          <label class="flex items-center cursor-pointer">
-            <input
-              type="radio"
-              v-model="preferences.units"
-              value="imperial"
-              data-test="units-imperial"
-              class="mr-2 text-green-600 focus:ring-green-500"
-            />
-            <span>{{ t('profile.preferences.imperial') }}</span>
-          </label>
-        </div>
-      </div>
-
-      <!-- Theme -->
-      <!-- <div>
-        <label for="theme" class="block text-sm font-medium text-gray-700 mb-2">
-          {{ t('profile.preferences.theme') }}
-        </label>
-        <select
-          id="theme"
-          v-model="preferences.theme"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-        >
-          <option value="light">{{ t('profile.preferences.themeLight') }}</option>
-          <option value="dark">{{ t('profile.preferences.themeDark') }}</option>
-          <option value="auto">{{ t('profile.preferences.themeAuto') }}</option>
-        </select>
-      </div> -->
-
-      <!-- Date Format -->
-      <!-- <div>
-        <label for="dateFormat" class="block text-sm font-medium text-gray-700 mb-2">
-          {{ t('profile.preferences.dateFormat') }}
-        </label>
-        <select
-          id="dateFormat"
-          v-model="preferences.dateFormat"
-          class="w-full px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring focus:border-green-300"
-        >
-          <option value="DD/MM/YYYY">DD/MM/YYYY</option>
-          <option value="MM/DD/YYYY">MM/DD/YYYY</option>
-          <option value="YYYY-MM-DD">YYYY-MM-DD</option>
-        </select>
-      </div> -->
-
-      <button
-        @click="savePreferences"
-        class="w-full bg-green-600 text-white py-2 rounded-md hover:bg-green-700"
-      >
-        {{ t('common.save') }}
-      </button>
-
-      <div v-if="saveSuccess" class="text-green-600 text-sm text-center">
-        {{ t('profile.preferences.saveSuccess') }}
-      </div>
-    </div>
+    </section>
   </div>
 </template>
 
@@ -131,3 +91,34 @@ const savePreferences = async () => {
   }, 3000)
 }
 </script>
+
+<style scoped>
+.units__choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+  color: var(--color-ink);
+  cursor: pointer;
+}
+
+.choice input {
+  accent-color: var(--color-green-600);
+}
+
+.saved {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-green-700);
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -193,16 +193,15 @@
       "section": "Identity"
     },
     "athlete": {
-      "title": "Profile",
       "section": "Athlete Information",
       "weight": "Weight (kg)",
       "maxHR": "Max Heart Rate (bpm)",
       "restingHR": "Resting Heart Rate (bpm)",
       "ftp": "FTP (watts)",
-      "saveSuccess": "Athlete profile saved"
+      "saveSuccess": "Athlete profile saved",
+      "lead": "Used for heart-rate zones, calories and power estimates."
     },
     "preferences": {
-      "title": "App Preferences",
       "units": "Unit System",
       "metric": "Metric (km)",
       "imperial": "Imperial (mi)",
@@ -296,20 +295,19 @@
     "quickManage": "Manage"
   },
   "dataProviders": {
-    "title": "Connected Data Providers",
-    "available": "Available Providers",
-    "noProviders": "No providers connected.",
-    "myProviders": "My Data Sources"
+    "available": "Available to connect",
+    "noProviders": "No source connected yet.",
+    "myProviders": "My sources"
   },
   "storageProviders": {
-    "title": "Connected File Plugins",
-    "available": "Available plugins",
-    "noPlugins": "No File Plugin connected.",
-    "myPlugins": "My Cloud Backups"
+    "available": "Available to connect",
+    "noPlugins": "No backup set up yet.",
+    "myPlugins": "My backup"
   },
   "appExtensions": {
-    "title": "App Extensions",
-    "description": "Manage widgets and features displayed throughout the app"
+    "title": "Extensions",
+    "description": "Each extension adds screens or blocks to the app. Turn off the ones you do not use.",
+    "toggle": "Turn {name} on or off"
   },
   "onboarding": {
     "provider": {
@@ -848,6 +846,44 @@
       "all": "All",
       "own": "Me",
       "friends": "Friends"
+    }
+  },
+  "extensions": {
+    "activity-privacy": {
+      "label": "Activity privacy",
+      "description": "Choose activity by activity what your friends can see."
+    },
+    "aggregated-details": {
+      "label": "Records and rankings",
+      "description": "Shows your personal bests and how each outing ranks against the rest."
+    },
+    "goals": {
+      "label": "Training goals",
+      "description": "Set weekly or monthly goals and follow your progress live."
+    },
+    "mcp": {
+      "label": "AI assistant (MCP)",
+      "description": "Connect your training data to Claude, ChatGPT or another assistant through the MCP protocol."
+    },
+    "metric-tracker": {
+      "label": "Single metric tracker",
+      "description": "Follow how one metric evolves over time, per outing or per period."
+    },
+    "profile-sharing": {
+      "label": "Sharing and privacy",
+      "description": "Manages your sharing settings and the publication of your public profile."
+    },
+    "standard-details": {
+      "label": "Activity detail",
+      "description": "Heart rate, cadence, speed graphs and zones for each outing."
+    },
+    "statistics": {
+      "label": "Statistics",
+      "description": "Trends, distributions, personal records and an activity calendar."
+    },
+    "firebase-notifications": {
+      "label": "Push notifications",
+      "description": "Get notified when new activities are imported."
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -193,16 +193,15 @@
       "section": "Identité"
     },
     "athlete": {
-      "title": "Profil",
       "section": "Informations athlète",
       "weight": "Poids (kg)",
       "maxHR": "FC max (bpm)",
       "restingHR": "FC repos (bpm)",
       "ftp": "FTP (watts)",
-      "saveSuccess": "Profil athlète sauvegardé"
+      "saveSuccess": "Profil athlète sauvegardé",
+      "lead": "Sert aux zones cardiaques, aux calories et aux estimations de puissance."
     },
     "preferences": {
-      "title": "Préférences de l'application",
       "units": "Système d'unités",
       "metric": "Métrique (km)",
       "imperial": "Impérial (mi)",
@@ -296,20 +295,19 @@
     "quickManage": "Gérer"
   },
   "dataProviders": {
-    "title": "Fournisseurs de données connectés",
-    "available": "Fournisseurs disponibles",
-    "noProviders": "Aucun fournisseur connecté.",
-    "myProviders": "Mes sources de données"
+    "available": "À connecter",
+    "noProviders": "Aucune source connectée pour l'instant.",
+    "myProviders": "Mes sources"
   },
   "storageProviders": {
-    "title": "Plugins de stockage connectés",
-    "available": "Plugins disponibles",
-    "noPlugins": "Aucun plugin de stockage connecté.",
-    "myPlugins": "Mes sauvegardes cloud"
+    "available": "À connecter",
+    "noPlugins": "Aucune sauvegarde configurée pour l'instant.",
+    "myPlugins": "Ma sauvegarde"
   },
   "appExtensions": {
-    "title": "Extensions d'application",
-    "description": "Gérez les widgets et fonctionnalités affichés dans l'application"
+    "title": "Extensions",
+    "description": "Chaque extension ajoute des écrans ou des blocs dans l'application. Désactivez celles dont vous ne vous servez pas.",
+    "toggle": "Activer ou désactiver {name}"
   },
   "onboarding": {
     "provider": {
@@ -848,6 +846,44 @@
       "all": "Tout",
       "own": "Moi",
       "friends": "Amis"
+    }
+  },
+  "extensions": {
+    "activity-privacy": {
+      "label": "Confidentialité des activités",
+      "description": "Choisissez activité par activité ce que vos amis peuvent voir."
+    },
+    "aggregated-details": {
+      "label": "Records et classements",
+      "description": "Affiche vos meilleures performances et votre classement sur l'ensemble de vos sorties."
+    },
+    "goals": {
+      "label": "Objectifs d'entraînement",
+      "description": "Fixez des objectifs hebdomadaires ou mensuels et suivez leur progression en direct."
+    },
+    "mcp": {
+      "label": "Assistant IA (MCP)",
+      "description": "Connectez vos données d'entraînement à Claude, ChatGPT ou un autre assistant via le protocole MCP."
+    },
+    "metric-tracker": {
+      "label": "Suivi d'une métrique",
+      "description": "Suivez l'évolution d'une seule métrique dans le temps, par sortie ou par période."
+    },
+    "profile-sharing": {
+      "label": "Partage et confidentialité",
+      "description": "Gère vos réglages de partage et la publication de votre profil public."
+    },
+    "standard-details": {
+      "label": "Détail des activités",
+      "description": "Graphiques de fréquence cardiaque, cadence, vitesse et zones pour chaque sortie."
+    },
+    "statistics": {
+      "label": "Statistiques",
+      "description": "Tendances, répartitions, records personnels et calendrier d'activité."
+    },
+    "firebase-notifications": {
+      "label": "Notifications push",
+      "description": "Recevez une notification quand de nouvelles activités sont importées."
     }
   }
 }

--- a/tests/unit/profileCoherence.spec.ts
+++ b/tests/unit/profileCoherence.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { createI18n } from 'vue-i18n'
+import fr from '@/locales/fr.json'
+import en from '@/locales/en.json'
+import { allAppPlugins } from '@/services/ExtensionPluginRegistry'
+
+const ROOT = join(import.meta.dirname, '..', '..')
+const PANELS = join(ROOT, 'src', 'components', 'profile')
+
+/**
+ * A tab is a tab whether core or a plugin renders it.
+ *
+ * The MCP extension contributes one through the `profile.tabs` slot, and it
+ * was the single largest holdout — 61 utility classes, more than the five core
+ * panels put together.
+ */
+const PLUGIN_PANELS = [join(ROOT, 'plugins', 'app-extensions', 'MCP', 'ProfileMCP.vue')]
+
+const panelFiles = () => [
+  ...readdirSync(PANELS)
+    .filter(f => f.endsWith('.vue'))
+    .map(f => join(PANELS, f)),
+  ...PLUGIN_PANELS
+]
+
+/**
+ * Six panels carried six copies of "a card", "a section title" and "a button",
+ * expressed in Tailwind utilities, and they had drifted: square cards next to
+ * rounded ones, three heading sizes, buttons green here and outlined there.
+ *
+ * The primitives now live once in `profile.css`, under `.profile-panel`. A
+ * panel that reaches for a utility class again is a panel that has started its
+ * own copy.
+ */
+describe('the profile panels share one vocabulary', () => {
+  const UTILITY =
+    /\bclass="[^"]*\b(space-y-\d|bg-white|bg-gray-\d+|text-(gray|green)-\d+|text-(sm|lg|xl|2xl)|font-(bold|semibold)|p-\d|px-\d|py-\d|rounded(-\w+)?|shadow)\b/
+
+  it('no panel styles itself with utility classes', () => {
+    const offenders = panelFiles()
+      .filter(f => UTILITY.test(readFileSync(f, 'utf8')))
+      .map(f => f.replace(ROOT + '/', ''))
+
+    expect(offenders, `Use the primitives in profile.css:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('every panel opts into the shared primitives', () => {
+    const files = panelFiles()
+    expect(files.length).toBeGreaterThan(4)
+
+    const offenders = files
+      .filter(f => !readFileSync(f, 'utf8').includes('profile-panel'))
+      .map(f => f.replace(ROOT + '/', ''))
+
+    expect(offenders, `Root element needs class="profile-panel":\n${offenders.join('\n')}`).toEqual(
+      []
+    )
+  })
+
+  /**
+   * The tab strip sits a few pixels above the panel and already names it. A
+   * panel repeating that name produced three headings for one list — "SOURCES
+   * DE DONNÉES", then "Fournisseurs de données connectés", then "Mes sources
+   * de données", three vocabularies for one thing.
+   */
+  it('no panel repeats the tab label as its own title', () => {
+    // Comments are stripped first: a panel explaining why it has no <h2> is
+    // not a panel with an <h2>, and the first run of this guard said otherwise.
+    const offenders = panelFiles()
+      .filter(f => /<h2[\s>]/.test(readFileSync(f, 'utf8').replace(/<!--[\s\S]*?-->/g, '')))
+      .map(f => f.replace(ROOT + '/', ''))
+
+    expect(offenders, `The tab strip is the title:\n${offenders.join('\n')}`).toEqual([])
+  })
+})
+
+/**
+ * Nine extensions declared an English `label` and `description` in their
+ * `index.ts`, and the tab rendered all nine in English to a French reader —
+ * the mirror image of the hardcoded French toasts.
+ */
+describe('every extension has a translated name', () => {
+  for (const locale of ['fr', 'en'] as const) {
+    it(`names and describes each extension in ${locale}`, () => {
+      const i18n = createI18n({ legacy: false, locale, messages: { fr, en } })
+      const te = i18n.global.te as (k: string) => boolean
+
+      const missing = allAppPlugins
+        .filter(p => !te(`extensions.${p.id}.label`))
+        .map(p => `extensions.${p.id}.label`)
+
+      expect(allAppPlugins.length).toBeGreaterThan(5)
+      expect(missing, `Missing from ${locale}.json:\n${missing.join('\n')}`).toEqual([])
+    })
+  }
+})


### PR DESCRIPTION
Sept panneaux portaient sept copies de « une carte », « un titre de section » et « un bouton », écrites en utilitaires Tailwind, et elles avaient divergé : des cartes à angles droits à côté de cartes arrondies, trois tailles de titre, des boutons verts ici et contournés là.

Les primitives vivent maintenant **une fois**, dans `profile.css`, sous `.profile-panel`. Un panneau qui redéclare une carte est un panneau qui a recommencé sa copie — un test le dit.

## L'essentiel n'était pas visuel

| L'onglet dit | Le panneau disait | Puis |
| --- | --- | --- |
| SOURCES DE DONNÉES | Fournisseurs de données connectés | Mes sources de données |
| SAUVEGARDE CLOUD | Plugins de stockage connectés | Mes sauvegardes cloud |

Trois mots pour une chose, trois titres pour une liste, et **« plugin » qui fuyait vers l'utilisateur**.

Aucun panneau ne répète plus le libellé de son onglet : la barre est à quelques pixels au-dessus et le panneau lui est déjà rattaché par `aria-labelledby`. Restent deux sections nommées par ce qu'elles contiennent — « Mes sources » et « À connecter » — avec **les mêmes mots des deux côtés**.

## Neuf extensions en anglais dans une UI française

C'est l'image en miroir exacte des douze toasts français mis sous test en #79 : chaque plugin déclarait un `label` et une `description` en anglais dans son `index.ts`, et l'onglet les affichait tels quels.

Elles se traduisent désormais depuis les locales, **indexées sur l'id du plugin**, avec la chaîne déclarée en repli. Aucun des neuf `index.ts` n'a bougé, et un plugin non traduit reste lisible.

## Trouvé en chemin

- **L'interrupteur des extensions flottait par-dessus la description** qu'il concernait, sur deux entrées. Il a sa colonne.
- Son `aria-label` était un `Toggle ${plugin.label}` **anglais en dur** — un littéral utilisateur.
- Le `<label>` de la photo de profil cachait son input en `hidden`, donc **hors du parcours clavier**.
- **L'onglet MCP est un onglet du profil**, contribué par un plugin via le slot `profile.tabs`, et c'était le plus gros retardataire : 61 classes utilitaires, plus que les cinq panneaux du cœur réunis. Le garde couvre les onglets de plugin pour cette raison.

## Tailwind : non, pas encore retirable

Le chiffre plutôt que la promesse — on passe de **284 attributs sur 22 fichiers à 132 sur 16**. Tout le profil est à zéro, il reste :

| Lot | attributs |
| --- | --- |
| Onboarding (3 écrans) | 49 |
| Setups de plugins (GDrive, Garmin, provider par défaut) | 44 |
| Graphes (ActivityBests, SpeedSampled, HeartZone, heatmap) | 34 |
| Divers (QRScanner, ActivityDetails, Callback) | 3 |

L'onboarding est le lot suivant le plus cohérent, et le plus visible : c'est le premier écran après la landing. Une fois les quatre lots faits, la dépendance, le plugin Vite et l'`@import` partent ensemble.

## Vérifications

Rendu contrôlé dans un vrai navigateur en **390px sur les sept onglets**, dont l'onglet MCP dans ses deux états (avec et sans espace cloud connecté).

**752 tests** verts (+5). Les quatre gardes validés en réintroduisant leur violation — dont un qui m'a d'abord pris en défaut : le commentaire expliquant « pas de `<h2>` ici » contenait la chaîne `<h2>`. Le garde ignore les commentaires maintenant.

`typecheck` (`vue-tsc`), ESLint, Prettier et build propres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_