### PR TITLE
fix(i18n): rendre ses accents au français

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -425,35 +425,35 @@
   "statistics": {
     "title": "Statistiques",
     "allSports": "Tous les sports",
-    "noData": "Aucune donnee disponible",
-    "noDataHint": "Importez des activites pour voir vos statistiques",
+    "noData": "Aucune donnée disponible",
+    "noDataHint": "Importez des activités pour voir vos statistiques",
     "summary": {
       "title": "Totaux",
-      "periodLabel": "Periode des totaux",
+      "periodLabel": "Période des totaux",
       "allSports": "Tous sports confondus : le filtre ne s'applique pas a ces totaux",
       "periods": {
         "week": "Cette semaine",
         "month": "Ce mois",
-        "year": "Cette annee"
+        "year": "Cette année"
       },
       "metrics": {
         "distance": "Distance",
-        "duration": "Duree",
-        "totalAscent": "Denivele +"
+        "duration": "Durée",
+        "totalAscent": "Dénivelé +"
       }
     },
     "trends": {
       "title": "Tendances",
       "distance": "Distance (km)",
-      "activities": "Activites",
+      "activities": "Activités",
       "week": "Semaine",
       "month": "Mois",
-      "year": "Annee",
+      "year": "Année",
       "distanceLabel": "Distance"
     },
     "distribution": {
-      "title": "Repartition",
-      "durationH": "Duree (h)",
+      "title": "Répartition",
+      "durationH": "Durée (h)",
       "distance": "Distance"
     },
     "records": {
@@ -463,26 +463,26 @@
       "pace": "Allure",
       "speed": "Vitesse",
       "date": "Date",
-      "activity": "Activite",
+      "activity": "Activité",
       "computing": "Calcul des records en cours...",
-      "noRecords": "Aucun record trouve",
-      "noRecordsHint": "Les records sont calcules a partir des donnees GPS de vos activites",
-      "noRecordsPeriodHint": "Aucun record sur la periode selectionnee",
-      "periodLabel": "Periode des records",
+      "noRecords": "Aucun record trouvé",
+      "noRecordsHint": "Les records sont calculés à partir des données GPS de vos activités",
+      "noRecordsPeriodHint": "Aucun record sur la période sélectionnée",
+      "periodLabel": "Période des records",
       "period": {
         "all": "Tout",
         "month": "Ce mois",
         "quarter": "Ce trimestre",
-        "year": "Cette annee"
+        "year": "Cette année"
       }
     },
     "heatmap": {
-      "title": "Calendrier d'activite",
+      "title": "Calendrier d'activité",
       "less": "Moins",
       "more": "Plus",
       "distance": "Distance",
-      "duration": "Duree",
-      "count": "Activites"
+      "duration": "Durée",
+      "count": "Activités"
     }
   },
   "setupBanner": {

--- a/tests/unit/contracts.spec.ts
+++ b/tests/unit/contracts.spec.ts
@@ -174,3 +174,61 @@ describe('the notification keys resolve in both locales', () => {
     })
   }
 })
+
+/**
+ * A French string carries its accents.
+ *
+ * Nineteen shipped without them, all on the statistics screen: "Duree",
+ * "Denivele +", "Calendrier d'activite", "Aucun record trouve", "Les records
+ * sont calcules a partir des donnees GPS". Fourteen had been there a while and
+ * four arrived with a new section, which is how it spreads — the surrounding
+ * copy already looked like that.
+ *
+ * The list below is deliberately narrow: each entry is a spelling that is not
+ * a French word at all. "moyenne" is correctly spelt without one and is not
+ * here; neither is anything that doubles as English.
+ */
+describe('the French locale is written in French', () => {
+  const UNACCENTED = [
+    'activite',
+    'activites',
+    'annee',
+    'annees',
+    'calcule',
+    'calcules',
+    'calculee',
+    'calculees',
+    'denivele',
+    'deniveles',
+    'donnee',
+    'donnees',
+    'duree',
+    'durees',
+    'energie',
+    'frequence',
+    'periode',
+    'periodes',
+    'repartition',
+    'selectionne',
+    'selectionnee',
+    'trouve',
+    'trouvee'
+  ]
+
+  it('no value drops an accent that makes the word French', async () => {
+    const messages = (await import('@/locales/fr.json')).default as Record<string, unknown>
+    const rx = new RegExp(`\\b(${UNACCENTED.join('|')})\\b`, 'i')
+
+    const offenders: string[] = []
+    const walk = (node: unknown, path: string) => {
+      if (typeof node === 'string') {
+        if (rx.test(node)) offenders.push(`${path} = ${node}`)
+      } else if (node && typeof node === 'object') {
+        for (const [k, v] of Object.entries(node)) walk(v, path ? `${path}.${k}` : k)
+      }
+    }
+    walk(messages, '')
+
+    expect(offenders, `Accents missing in fr.json:\n${offenders.join('\n')}`).toEqual([])
+  })
+})


### PR DESCRIPTION
Dix-neuf chaînes s'affichaient **sans accents**, toutes sur l'écran des statistiques :

> « Duree » · « Denivele + » · « Calendrier d'activite » · « Aucun record trouve » · « Les records sont calcules a partir des donnees GPS de vos activites »

## Comment ça se propage

**Quatorze traînaient depuis un moment, cinq sont arrivées avec une section neuve** (la `SummarySection` de #87). C'est le mécanisme : la copie voisine avait déjà cette tête, donc la nouvelle l'a imitée. Sans garde, la prochaine section fera pareil.

## Le garde

Ajouté dans `contracts.spec.ts`, qui héberge déjà les règles qui se font enfreindre. Sa liste est **volontairement courte** : chaque entrée est une orthographe qui n'est pas un mot français du tout.

- « moyenne » s'écrit correctement sans accent et **n'y figure pas** — il était dans mon premier balayage et c'était un faux positif.
- Rien qui soit aussi un mot anglais n'y figure non plus, pour que le garde ne se déclenche pas sur une clé volontairement anglophone.

## Vérifications

Rendu contrôlé dans un navigateur sur `/statistics` en 390px : **plus un seul de ces mots à l'écran**. Le garde a été validé en retirant un accent avant restauration.

**760 tests** verts (+1), `typecheck` (`vue-tsc`), ESLint, Prettier et build propres.

Le diff ne touche que `src/locales/fr.json` et le fichier de tests — surface minimale, parce qu'un autre agent travaille sur les composants Statistics en parallèle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH

---
_Generated by [Claude Code](https://claude.ai/code/session_014oPksLGMJHUmAqbWLiWxBH)_