### PR TITLE
fix(gdrive): sign in to Google the way a native app can

### DIFF
--- a/.github/workflows/build-android-test.yml
+++ b/.github/workflows/build-android-test.yml
@@ -47,10 +47,19 @@ jobs:
 
       - name: Build web app
         run: npm run build
+        env:
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
+          VITE_GOOGLE_CLIENT_SECRET: ${{ secrets.VITE_GOOGLE_CLIENT_SECRET }}
+          VITE_GOOGLE_DRIVE_API_KEY: ${{ secrets.VITE_GOOGLE_DRIVE_API_KEY }}
+          # The native app signs in as its own OAuth client: a Web client only
+          # accepts http(s) redirect URIs, and this app has no origin worth
+          # redirecting to. Unset → the Drive screen says so instead of sending
+          # the user to a redirect_uri_mismatch.
+          VITE_GOOGLE_NATIVE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_NATIVE_CLIENT_ID }}
 
       - name: Add Capacitor Android + health plugin
         run: |
-          npm install @capacitor/cli@^8 @capacitor/android@^8 capacitor-health @capacitor-community/background-geolocation
+          npm install @capacitor/cli@^8 @capacitor/android@^8 capacitor-health @capacitor-community/background-geolocation @capacitor/browser @capacitor/app
           # ci/capacitor.config.json carries android.useLegacyBridge — without it
           # background-geolocation stops delivering fixes ~5 min after the app is
           # backgrounded, which reads exactly like "the GPS module gave up".
@@ -71,6 +80,38 @@ jobs:
           MANIFEST="android/app/src/main/AndroidManifest.xml"
           sed -i 's|</manifest>|    <uses-permission android:name="android.permission.health.READ_EXERCISE" />\n    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />\n    <uses-permission android:name="android.permission.health.READ_EXERCISE_ROUTE" />\n    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />\n    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />\n    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />\n    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />\n    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />\n    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />\n</manifest>|' "$MANIFEST"
           echo "--- patched manifest ---"; cat "$MANIFEST"
+
+      # The OAuth callback comes back as a deep link on the reverse of the client
+      # id (`123-abc.apps.googleusercontent.com` →
+      # `com.googleusercontent.apps.123-abc`), which is the only redirect shape
+      # Google accepts for a native client. Without this filter the system
+      # browser finishes the sign-in and has nowhere to hand the code back to.
+      - name: Register the OAuth deep-link scheme
+        env:
+          NATIVE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_NATIVE_CLIENT_ID }}
+        run: |
+          if [ -z "$NATIVE_CLIENT_ID" ]; then
+            echo "VITE_GOOGLE_NATIVE_CLIENT_ID is not set — skipping (Drive sign-in will be unavailable in this build)."
+            exit 0
+          fi
+          python3 - <<'PY'
+          import os
+          scheme = '.'.join(reversed(os.environ['NATIVE_CLIENT_ID'].split('.')))
+          path = 'android/app/src/main/AndroidManifest.xml'
+          xml = open(path).read()
+          filt = f'''
+                  <intent-filter>
+                      <action android:name="android.intent.action.VIEW" />
+                      <category android:name="android.intent.category.DEFAULT" />
+                      <category android:name="android.intent.category.BROWSABLE" />
+                      <data android:scheme="{scheme}" />
+                  </intent-filter>
+              </activity>'''
+          assert '</activity>' in xml, 'no activity to attach the scheme to'
+          open(path, 'w').write(xml.replace('</activity>', filt.strip('\n'), 1))
+          print('registered scheme', scheme)
+          PY
+          echo "--- patched manifest ---"; cat android/app/src/main/AndroidManifest.xml
 
       # Persist the debug signing key across builds so updates install over each
       # other (a fresh runner would otherwise sign every build with a different

--- a/.github/workflows/build-android-test.yml
+++ b/.github/workflows/build-android-test.yml
@@ -116,11 +116,19 @@ jobs:
       # Persist the debug signing key across builds so updates install over each
       # other (a fresh runner would otherwise sign every build with a different
       # random debug key → "App not installed" on reinstall).
+      # `~/.config/.android` is where AGP actually puts it on this runner — it
+      # follows XDG_CONFIG_HOME, and neither ANDROID_USER_HOME nor
+      # ANDROID_PREFS_ROOT is set. The old `~/.android` path never existed, so
+      # every build signed with a fresh random key and the cache saved nothing:
+      # exactly the "App not installed" this step was added to prevent. Both
+      # paths are listed because only the runner decides which one is real.
       - name: Cache the debug signing key
         uses: actions/cache@v4
         with:
-          path: ~/.android/debug.keystore
-          key: android-debug-keystore-v1
+          path: |
+            ~/.config/.android/debug.keystore
+            ~/.android/debug.keystore
+          key: android-debug-keystore-v2
 
       - name: Build debug APK
         run: |

--- a/.github/workflows/build-android-test.yml
+++ b/.github/workflows/build-android-test.yml
@@ -13,7 +13,7 @@ on:
   # Runs automatically on every push to this branch (so it works without the
   # workflow being on the default branch), plus a manual trigger.
   push:
-    branches: [feat/health-native]
+    branches: [feat/health-native, claude/capacitor-geolocation-issues-3fge7v]
   workflow_dispatch:
 
 jobs:
@@ -127,6 +127,19 @@ jobs:
           cd android
           chmod +x ./gradlew
           ./gradlew assembleDebug --no-daemon --stacktrace
+
+      # Google identifies an Android OAuth client by package name + signing
+      # fingerprint, and this keystore lives in the Actions cache — nowhere a
+      # human can read it. Printing it is the only way to fill in the console
+      # form. It is the *debug* fingerprint: a Play Store build is signed with a
+      # different key and needs its own client.
+      - name: Print the debug signing fingerprint (for the OAuth client)
+        run: |
+          echo "Register this SHA-1 against package app.openstride in the Google Cloud Console:"
+          keytool -list -v \
+            -keystore ~/.android/debug.keystore \
+            -alias androiddebugkey -storepass android -keypass android \
+            | grep -E 'SHA1|SHA256'
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android-test.yml
+++ b/.github/workflows/build-android-test.yml
@@ -162,12 +162,20 @@ jobs:
       - name: Print the debug signing fingerprint (for the OAuth client)
         continue-on-error: true
         run: |
-          KEYSTORE="$HOME/.android/debug.keystore"
-          if [ ! -f "$KEYSTORE" ]; then
-            echo "No debug keystore at $KEYSTORE — nothing to fingerprint."
+          # Not hardcoded to ~/.android: the cache step reports that path does
+          # not exist, so AGP is putting the keystore somewhere else on this
+          # runner (ANDROID_USER_HOME / ANDROID_PREFS_ROOT move it). Find it,
+          # and print where it was — the cache key needs the same answer.
+          echo "ANDROID_USER_HOME=${ANDROID_USER_HOME:-unset} ANDROID_PREFS_ROOT=${ANDROID_PREFS_ROOT:-unset} ANDROID_SDK_HOME=${ANDROID_SDK_HOME:-unset}"
+          KEYSTORE=$(find "$HOME" "$RUNNER_TEMP" "${ANDROID_USER_HOME:-/nonexistent}" \
+                          "${ANDROID_PREFS_ROOT:-/nonexistent}" \
+                          -name debug.keystore -type f 2>/dev/null | head -1)
+          if [ -z "$KEYSTORE" ]; then
+            echo "No debug.keystore found — the APK is signed, but not from a keystore on disk."
             exit 0
           fi
+          echo "Found the debug keystore at: $KEYSTORE"
           echo "Register this SHA-1 against package app.openstride in the Google Cloud Console:"
           keytool -list -v -keystore "$KEYSTORE" -alias androiddebugkey -storepass android 2>&1 \
             | grep -E 'SHA1|SHA256' \
-            || echo "keytool printed no fingerprint (see the raw output above)."
+            || echo "keytool printed no fingerprint (raw output above)."

--- a/.github/workflows/build-android-test.yml
+++ b/.github/workflows/build-android-test.yml
@@ -128,19 +128,6 @@ jobs:
           chmod +x ./gradlew
           ./gradlew assembleDebug --no-daemon --stacktrace
 
-      # Google identifies an Android OAuth client by package name + signing
-      # fingerprint, and this keystore lives in the Actions cache — nowhere a
-      # human can read it. Printing it is the only way to fill in the console
-      # form. It is the *debug* fingerprint: a Play Store build is signed with a
-      # different key and needs its own client.
-      - name: Print the debug signing fingerprint (for the OAuth client)
-        run: |
-          echo "Register this SHA-1 against package app.openstride in the Google Cloud Console:"
-          keytool -list -v \
-            -keystore ~/.android/debug.keystore \
-            -alias androiddebugkey -storepass android -keypass android \
-            | grep -E 'SHA1|SHA256'
-
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
@@ -162,3 +149,25 @@ jobs:
             --notes "Latest debug APK from \`${GITHUB_REF_NAME}\` (commit \`${GITHUB_SHA:0:7}\`). Install: allow install from unknown sources, then open the APK." \
             --prerelease \
             --target "${GITHUB_SHA}"
+
+      # Google identifies an Android OAuth client by package name + signing
+      # fingerprint, and this keystore lives in the Actions cache — nowhere a
+      # human can read it. Printing it is the only way to fill in the console
+      # form. It is the *debug* fingerprint: a Play Store build is signed with a
+      # different key and needs its own client.
+      #
+      # Last, and `continue-on-error`, on purpose: this is a diagnostic, and a
+      # diagnostic that can withhold the APK is worse than no diagnostic. The
+      # first version of this step sat before the upload and did exactly that.
+      - name: Print the debug signing fingerprint (for the OAuth client)
+        continue-on-error: true
+        run: |
+          KEYSTORE="$HOME/.android/debug.keystore"
+          if [ ! -f "$KEYSTORE" ]; then
+            echo "No debug keystore at $KEYSTORE — nothing to fingerprint."
+            exit 0
+          fi
+          echo "Register this SHA-1 against package app.openstride in the Google Cloud Console:"
+          keytool -list -v -keystore "$KEYSTORE" -alias androiddebugkey -storepass android 2>&1 \
+            | grep -E 'SHA1|SHA256' \
+            || echo "keytool printed no fingerprint (see the raw output above)."

--- a/docs/plans/CAPACITOR_GEOLOCATION.md
+++ b/docs/plans/CAPACITOR_GEOLOCATION.md
@@ -72,6 +72,33 @@ hundred metres of climb. When a fix is refused for accuracy the screen says so �
 a mute "waiting for GPS" over a frozen distance is the moment the user decides
 the recorder is broken.
 
+## 6. `location.speed` is not the speed of the activity
+
+The first real recording came back with a correct average pace next to a pace
+graph that was nonsense — and the same graph is right for a Garmin activity, on
+the same screen. Nothing was wrong with the graph.
+
+The two numbers simply came from unrelated quantities. The summary divides
+distance by duration. `SpeedSampled` plots `SegmentSample.speed`, which
+`computeAverageSample` builds as the arithmetic mean of `sample.speed`. Garmin's
+adapter fills that field with `speedMetersPerSecond`, the watch's own smoothed
+1 Hz figure. The recorder filled it with the Capacitor plugin's raw
+per-fix Doppler estimate: one instant, sometimes absent entirely, and tied to
+nothing the activity is summarised from.
+
+`speedSeries()` measures it on the track instead, over a 30 m window, in moving
+**milliseconds**. Both halves matter:
+
+- fixes arrive roughly every 5 m — under two seconds of running — and
+  `sample.time` is stored in whole seconds, so a speed taken between neighbours
+  divides a small distance by a heavily quantised time;
+- a pause between two fixes would otherwise read as a dead stop.
+
+The graph and the summary now come from the same distances and the same clock,
+so they agree by construction. `maxSpeed` comes from the measured series too: a
+single Doppler spike used to be enough to file a run with an impossible top
+speed.
+
 ## Still open
 
 - The HUD formats km and pace by hand. When this branch meets `ctx.units`

--- a/docs/plans/CAPACITOR_GEOLOCATION.md
+++ b/docs/plans/CAPACITOR_GEOLOCATION.md
@@ -86,18 +86,32 @@ adapter fills that field with `speedMetersPerSecond`, the watch's own smoothed
 per-fix Doppler estimate: one instant, sometimes absent entirely, and tied to
 nothing the activity is summarised from.
 
-`speedSeries()` measures it on the track instead, over a 30 m window, in moving
-**milliseconds**. Both halves matter:
+`speedSeries()` measures it on the track instead — Δdistance / Δtime, which is
+as simple as it sounds. Two details are not obvious:
 
-- fixes arrive roughly every 5 m — under two seconds of running — and
-  `sample.time` is stored in whole seconds, so a speed taken between neighbours
-  divides a small distance by a heavily quantised time;
-- a pause between two fixes would otherwise read as a dead stop.
+- **Moving milliseconds, not `sample.time`.** The stored field is whole seconds,
+  and fixes arrive every ~5 m, under two seconds apart. Using moving time also
+  keeps a pause between two fixes from reading as a dead stop.
+- **A 30 m window rather than the previous fix.** This one buys less than it
+  looks. Simulated against a 3 m/s run with 3 m of position error per fix, once
+  the graph has averaged its 100 m segment — the finest granularity offered —
+  the window and plain neighbour-to-neighbour are indistinguishable (sd 0.48 vs
+  0.43). It earns its place on `maxSpeed`, a raw per-sample maximum with no
+  averaging in front of it: neighbours peaked at 10.2 m/s on that run, the
+  window at 7.4, against a truth of 3.
 
 The graph and the summary now come from the same distances and the same clock,
-so they agree by construction. `maxSpeed` comes from the measured series too: a
-single Doppler spike used to be enough to file a run with an impossible top
-speed.
+so they agree by construction.
+
+### What this does not fix
+
+GPS position error inflates measured path length — every wobble adds distance a
+straight line did not travel — and that inflation lands in `activity.distance`,
+so it reaches the average and the graph alike. The simulation above puts it at
++39 %, but with _independent_ error per fix, which real GPS is not: consecutive
+fixes share most of their error, and the observed average pace on a real
+recording was sound. Treat that figure as an upper bound on a pathological day,
+not as a measurement of this recorder.
 
 ## Still open
 

--- a/docs/plans/CAPACITOR_OAUTH.md
+++ b/docs/plans/CAPACITOR_OAUTH.md
@@ -1,0 +1,83 @@
+# OAuth in the native app — why the web flow does not survive the WebView
+
+Every OAuth flow in this app was written for a browser tab, and a Capacitor
+WebView is not one. Two assumptions break, and they break silently: the user
+taps Connect, something happens, and nothing comes back.
+
+## 1. There is no origin worth redirecting to
+
+With `androidScheme: "https"` the app is served from **`https://localhost`**. So
+every `redirect_uri` built from `window.location.origin` — and they all were —
+is a URI no provider console has ever heard of.
+
+For Google that is `Error 400: redirect_uri_mismatch`, which is the error the
+Drive screen produced in the APK.
+
+## 2. Google will not show its sign-in page inside a WebView
+
+Even with the URI fixed. Google refuses embedded WebViews outright
+(`disallowed_useragent`, "this app may not be secure"). That is policy, not
+configuration, so no amount of console work makes
+`window.location.href = accounts.google.com/…` work from inside the app.
+
+The way out is to leave the app: a Custom Tab on Android, `SFSafariViewController`
+on iOS — a real browser — and to come back through a deep link.
+`nativeShell.authorize()` (`src/services/NativeShellService.ts`) is that round
+trip, and plugins reach it through `ctx.shell`.
+
+## 3. A native app is a different OAuth client
+
+A **Web** client only accepts http(s) redirect URIs and carries a `client_secret`.
+Neither fits an APK: there is no https origin, and there is nowhere to hide a
+secret in a bundle anyone can unzip.
+
+So the native app authenticates as its own client, and Google is explicit about
+the shape of its redirect — the reverse of the client id:
+
+```
+123-abc.apps.googleusercontent.com   →   com.googleusercontent.apps.123-abc:/oauth2redirect
+```
+
+No secret comes with it. PKCE stands in, which this codebase already did for the
+web flow.
+
+Three places have to agree on that scheme, or the browser finishes the sign-in
+and has nowhere to hand the code back to:
+
+| Where                          | What                                                  |
+| ------------------------------ | ----------------------------------------------------- |
+| Google Cloud Console           | an **Android** OAuth client (package + SHA-1)         |
+| `VITE_GOOGLE_NATIVE_CLIENT_ID` | the client id, injected at build time                 |
+| `AndroidManifest.xml`          | an `intent-filter` on the reversed id (CI derives it) |
+
+A build without the secret still installs and runs — the Drive screen says it
+cannot sign in, instead of sending the user to a redirect_uri_mismatch.
+
+## 4. A popup is not a channel
+
+Garmin does not use a redirect; it opens a popup and waits for a `postMessage`,
+with a `BroadcastChannel` as backup. In the native shell Capacitor hands
+`window.open` to the system browser, which has no `opener` to message through
+and shares no BroadcastChannel with the WebView. The popup opens, the user signs
+in, and the app waits forever.
+
+Garmin does _not_ refuse WebViews the way Google does, so the redirect flow the
+component already carries as its popup-blocked fallback is enough: on native
+`connectToGarmin()` goes straight to `connectWithRedirect()`, which lands back
+on `https://localhost/oauth/garmin/callback` — the app's own route, served by
+Capacitor.
+
+**That redirect URI has to be registered in the Garmin console**, and it has not
+been verified on a device. If Garmin rejects `https://localhost`, the fallback is
+the same shape as Google's: a custom scheme through `ctx.shell.authorize()`.
+
+## What is done, and what is not
+
+- Drive: implemented and unit-tested (`tests/unit/GDriveNativeAuth.spec.ts`,
+  `tests/unit/NativeShellService.spec.ts`). Needs the Android OAuth client to
+  exist before it can work on a phone.
+- Garmin: one-line redirect on native, unverified. Needs the redirect URI in the
+  Garmin console.
+- iOS: `NativeShellService` is platform-agnostic, but the iOS build registers no
+  URL scheme yet — that is a `CFBundleURLTypes` entry in the deploy workflow,
+  and an iOS OAuth client alongside the Android one.

--- a/docs/plans/CAPACITOR_OAUTH.md
+++ b/docs/plans/CAPACITOR_OAUTH.md
@@ -53,6 +53,23 @@ and has nowhere to hand the code back to:
 A build without the secret still installs and runs — the Drive screen says it
 cannot sign in, instead of sending the user to a redirect_uri_mismatch.
 
+### The signing key has to be stable first
+
+Google ties an Android OAuth client to a signing fingerprint, so registering one
+is only meaningful if the debug key survives between builds. It did not: the
+cache pointed at `~/.android/debug.keystore`, and AGP follows `XDG_CONFIG_HOME`
+and writes `~/.config/.android/debug.keystore`. Nothing was ever cached, every
+build signed with a fresh random key — which is also why installing an update
+over a previous APK failed with "App not installed".
+
+Two consecutive builds produced two different fingerprints, which is how this
+surfaced. The cache path is fixed and the key is saved under
+`android-debug-keystore-v2`.
+
+It is still a _cache_: GitHub evicts entries untouched for 7 days. If the
+fingerprint ever changes again, that is why, and the durable answer is to keep
+the keystore as a base64 repo secret rather than let CI generate it.
+
 ## 4. A popup is not a channel
 
 Garmin does not use a redirect; it opens a popup and waits for a `postMessage`,

--- a/env.d.ts
+++ b/env.d.ts
@@ -8,6 +8,20 @@ declare const __BUILD_TIME__: string
 declare global {
   var __APP_VERSION__: string
   var __BUILD_TIME__: string
+
+  // Merges with vite/client's declaration. This file is a module (it exports),
+  // so the augmentation has to live in `declare global` to reach anything.
+  interface ImportMetaEnv {
+    readonly VITE_GOOGLE_CLIENT_ID: string
+    readonly VITE_GOOGLE_CLIENT_SECRET: string
+    /**
+     * The OAuth client the *native* app authenticates as — a different client
+     * from the web one, redirecting to a custom scheme and carrying no secret.
+     * Absent from a web build, and absent from a native build nobody
+     * configured: the Drive screen says so rather than failing at Google's door.
+     */
+    readonly VITE_GOOGLE_NATIVE_CLIENT_ID?: string
+  }
 }
 
 export {}

--- a/plugins/app-extensions/RecorderQuickAction/RecorderQuickAction.vue
+++ b/plugins/app-extensions/RecorderQuickAction/RecorderQuickAction.vue
@@ -1,0 +1,281 @@
+<template>
+  <!--
+    Two placements on purpose, because there are two jobs.
+
+    Idle, it is an entry point among the other home cards: occasional, worth
+    finding, not worth floating over the feed. Recording, it is a live control
+    that has to be reachable with a thumb while moving, so it anchors to the
+    bottom of the screen and stays there while the user scrolls the feed.
+  -->
+  <div v-if="visible && phase === 'idle'" class="qa-card" data-test="recorder-quick-action">
+    <div class="qa-card__head">
+      <i class="fas fa-circle-dot" aria-hidden="true"></i>
+      <span>{{ t('recorderQuickAction.title') }}</span>
+    </div>
+    <div class="qa-card__row">
+      <label class="sr-only" for="qa-sport">{{ t('providers.recorder.chooseSport') }}</label>
+      <select id="qa-sport" v-model="sport" class="qa-select">
+        <option v-for="s in sports" :key="s" :value="s">{{ formatSportType(s) }}</option>
+      </select>
+      <button class="qa-btn qa-btn--go" data-test="recorder-start" @click="onStart">
+        <i class="fas fa-play" aria-hidden="true"></i> {{ t('providers.recorder.start') }}
+      </button>
+    </div>
+    <p v-if="error" class="qa-error">
+      <i class="fas fa-triangle-exclamation" aria-hidden="true"></i> {{ error }}
+    </p>
+  </div>
+
+  <div v-else-if="visible" class="qa-bar" data-test="recorder-quick-action">
+    <div class="qa-bar__stats">
+      <span class="qa-bar__time">{{ fmtDuration(stats.duration) }}</span>
+      <span class="qa-bar__dist">{{ distanceText }}</span>
+      <span v-if="phase === 'paused'" class="qa-bar__paused">
+        {{ t('recorderQuickAction.paused') }}
+      </span>
+    </div>
+    <div class="qa-bar__actions">
+      <button
+        v-if="phase === 'recording'"
+        class="qa-btn qa-btn--pause"
+        data-test="recorder-pause"
+        @click="onPause"
+      >
+        <i class="fas fa-pause" aria-hidden="true"></i> {{ t('providers.recorder.pause') }}
+      </button>
+      <button v-else class="qa-btn qa-btn--go" data-test="recorder-resume" @click="onResume">
+        <i class="fas fa-play" aria-hidden="true"></i> {{ t('providers.recorder.resume') }}
+      </button>
+      <button class="qa-btn qa-btn--stop" data-test="recorder-finish" @click="onFinish">
+        <i class="fas fa-stop" aria-hidden="true"></i> {{ t('providers.recorder.stop') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { usePluginContext } from '@/composables/usePluginContext'
+import { formatSportType, COMMON_SPORT_TYPES } from '@/utils/sportLabels'
+import type { SportType } from '@/types/sport'
+import { liveStats } from '@plugins/data-providers/RecorderProvider/client/recorder'
+import * as recorder from '@plugins/data-providers/RecorderProvider/client/session'
+
+const RECORDER_PROVIDER_ID = 'recorder'
+const LAST_SPORT_KEY = 'recorder:lastSport'
+
+const { t } = useI18n()
+const ctx = usePluginContext()
+
+const visible = ref(false)
+const error = ref('')
+const sports = COMMON_SPORT_TYPES as SportType[]
+const sport = ref<SportType>('running')
+
+const state = recorder.state
+const phase = computed(() => state.phase)
+
+const nowMs = ref(Date.now())
+let ticker: ReturnType<typeof setInterval> | null = null
+
+const stats = computed(() => liveStats(state.session, nowMs.value))
+/** Through `units`, never `/ 1000`: the reader may be on miles. */
+const distanceText = computed(() => ctx.units.format('distance', stats.value.distance).text)
+
+const notification = computed(() => ({
+  title: t('providers.recorder.notificationTitle'),
+  message: t('providers.recorder.notificationMessage')
+}))
+
+function fmtDuration(sec: number): string {
+  const h = Math.floor(sec / 3600)
+  const m = Math.floor((sec % 3600) / 60)
+  const s = sec % 60
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`
+}
+
+function startTicker() {
+  if (!ticker) ticker = setInterval(() => (nowMs.value = Date.now()), 1000)
+}
+function stopTicker() {
+  if (ticker) clearInterval(ticker)
+  ticker = null
+}
+
+function report(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err)
+  if (message === 'cancelled') return
+  error.value = t('providers.recorder.error', { message })
+}
+
+async function onStart() {
+  error.value = ''
+  startTicker()
+  try {
+    await ctx.storage.saveData(LAST_SPORT_KEY, sport.value)
+    await recorder.start(sport.value, notification.value)
+  } catch (err) {
+    report(err)
+    stopTicker()
+  }
+}
+
+async function onPause() {
+  try {
+    await recorder.pause()
+  } catch (err) {
+    report(err)
+  }
+}
+
+async function onResume() {
+  try {
+    await recorder.resume(notification.value)
+  } catch (err) {
+    report(err)
+  }
+}
+
+async function onFinish() {
+  stopTicker()
+  try {
+    const activity = await recorder.finish()
+    ctx.notifications.notify(
+      activity ? t('providers.recorder.saved') : t('providers.recorder.nothingRecorded'),
+      { type: activity ? 'success' : 'warning' }
+    )
+  } catch (err) {
+    report(err)
+  }
+}
+
+onMounted(async () => {
+  // The slot already answered "are we native"; this answers "did the user turn
+  // the recorder on". A provider nobody enabled has no business owning the top
+  // of the feed.
+  visible.value = await ctx.plugins.isPluginActive(RECORDER_PROVIDER_ID)
+  if (!visible.value) return
+
+  // Picks up a recording an app kill interrupted, so it can be finished from
+  // here without first finding the provider's setup page.
+  await recorder.restore()
+  const last = await ctx.storage.getData<SportType>(LAST_SPORT_KEY)
+  sport.value = state.session.sport ?? last ?? 'running'
+  nowMs.value = Date.now()
+  if (state.phase !== 'idle') startTicker()
+})
+
+onUnmounted(stopTicker)
+</script>
+
+<style scoped>
+.qa-card {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  margin-bottom: 1rem;
+}
+.qa-card__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  margin-bottom: 0.7rem;
+  color: var(--color-ink, #1e1e2e);
+}
+.qa-card__row {
+  display: flex;
+  gap: 0.6rem;
+}
+.qa-select {
+  flex: 1;
+  min-width: 0;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--color-border, #e5e7eb);
+  border-radius: 10px;
+  background: var(--color-surface, #fff);
+  color: var(--color-ink, #1e1e2e);
+}
+.qa-error {
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--color-red-600, #dc2626);
+}
+
+/* Anchored, above the safe area so the finish button is not under a home bar. */
+.qa-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.7rem 1rem calc(0.7rem + env(safe-area-inset-bottom));
+  background: var(--color-surface, #fff);
+  border-top: 1px solid var(--color-border, #e5e7eb);
+  box-shadow: 0 -4px 16px rgb(0 0 0 / 8%);
+}
+.qa-bar__stats {
+  display: flex;
+  align-items: baseline;
+  gap: 0.7rem;
+  min-width: 0;
+}
+.qa-bar__time {
+  font-size: 1.3rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-ink, #1e1e2e);
+}
+.qa-bar__dist {
+  font-size: 0.95rem;
+  color: var(--color-gray-600, #4b5563);
+}
+.qa-bar__paused {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--color-yellow-600, #d97706);
+}
+.qa-bar__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.qa-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--color-white, #fff);
+}
+.qa-btn--go {
+  background: var(--color-green-600, #4d7c0f);
+}
+.qa-btn--pause {
+  background: var(--color-yellow-500, #f59e0b);
+}
+.qa-btn--stop {
+  background: var(--color-red-600, #dc2626);
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/plugins/app-extensions/RecorderQuickAction/index.ts
+++ b/plugins/app-extensions/RecorderQuickAction/index.ts
@@ -1,0 +1,33 @@
+import { Capacitor } from '@capacitor/core'
+import type { ExtensionPlugin } from '@/types/extension'
+
+/**
+ * Start, pause and finish a recording without going through the provider's
+ * setup page.
+ *
+ * It lives here rather than in `RecorderProvider` because only an app extension
+ * can contribute to a slot, and it drives that provider's session module
+ * directly — the two are one feature wearing two plugin types.
+ *
+ * `appliesTo` answers on the platform, synchronously, so the web build never
+ * loads the chunk: everything behind it talks to a native geolocation plugin
+ * that is not there. Whether the recorder itself is switched on is a question
+ * with an async answer, so the component asks it on mount.
+ */
+const plugin: ExtensionPlugin = {
+  id: 'recorder-quick-action',
+  label: 'Record activity — quick action',
+  description: 'Start, pause and finish a GPS recording from the home screen',
+  icon: 'fas fa-circle-dot',
+  slots: {
+    'home.top': [
+      {
+        id: 'recorder-quick-action',
+        component: () => import('./RecorderQuickAction.vue'),
+        appliesTo: () => Capacitor.isNativePlatform()
+      }
+    ]
+  }
+}
+
+export default plugin

--- a/plugins/data-providers/GarminProvider/client/GarminSetup.vue
+++ b/plugins/data-providers/GarminProvider/client/GarminSetup.vue
@@ -148,6 +148,14 @@ let oauthChannel: BroadcastChannel | null = null
 // ============================================================================
 
 async function connectToGarmin() {
+  // A popup cannot come back inside the native shell: Capacitor hands
+  // `window.open` to the system browser, which has no `opener` to postMessage
+  // through and shares no BroadcastChannel with the WebView. The redirect flow
+  // does work there — the app is served from `https://localhost`, so
+  // `/oauth/garmin/callback` lands back on our own callback route — provided
+  // that redirect URI is registered in the Garmin console.
+  if (ctx.shell.isNative) return connectWithRedirect()
+
   // Generate PKCE verifier + challenge
   const codeVerifier = generateCodeVerifier()
   const codeChallenge = await generateCodeChallenge(codeVerifier)

--- a/plugins/data-providers/RecorderProvider/client/recorder.ts
+++ b/plugins/data-providers/RecorderProvider/client/recorder.ts
@@ -121,10 +121,23 @@ export function movingSecondsAt(session: RecordSession, atMs: number): number {
 /**
  * Metres a sample's speed is averaged over.
  *
- * Two fixes 5 m apart span under two seconds of running, and `sample.time` is
- * stored in whole seconds, so a speed taken between neighbours is a small
- * distance divided by a heavily quantised time — noise. Thirty metres is long
- * enough to be stable and short enough to still show a hill.
+ * Worth being honest about how little this buys, so nobody widens it expecting
+ * miracles. Measured against a simulated 3 m/s run with 3 m of position error
+ * per fix, once the pace graph has averaged its 100 m segment — the finest
+ * granularity the UI offers — a window of 30 m and a plain Δd/Δt between
+ * neighbours are indistinguishable (sd 0.48 against 0.43). The displayed curve
+ * does not need it.
+ *
+ * What does need it is `maxSpeed`, which is a raw per-sample maximum with no
+ * segment averaging in front of it: on that same run, neighbours peaked at
+ * 10.2 m/s and the window at 7.4 m/s, against a truth of 3. A single pair of
+ * fixes that both happen to err outward is enough to file a run with an
+ * impossible top speed.
+ *
+ * Note that the time axis is *not* the reason. With exact positions both
+ * methods return the true speed to the last decimal, because the measurement
+ * uses raw millisecond timestamps rather than the whole seconds `sample.time`
+ * is stored in.
  */
 export const SPEED_WINDOW_M = 30
 

--- a/plugins/data-providers/RecorderProvider/client/recorder.ts
+++ b/plugins/data-providers/RecorderProvider/client/recorder.ts
@@ -104,13 +104,57 @@ export function pausedMsAt(session: RecordSession, nowMs: number): number {
   return Math.max(0, paused)
 }
 
+/** Milliseconds of moving time elapsed at wall-clock `atMs`, unrounded. */
+export function movingMsAt(session: RecordSession, atMs: number): number {
+  return Math.max(0, atMs - session.startTime - pausedMsAt(session, atMs))
+}
+
 /**
  * Seconds of moving time elapsed at wall-clock `atMs`. The one time axis of the
  * recording: `activity.duration` and every `sample.time` are read off it, so a
  * pause can no longer leave the last sample sitting past the end of the activity.
  */
 export function movingSecondsAt(session: RecordSession, atMs: number): number {
-  return Math.max(0, Math.round((atMs - session.startTime - pausedMsAt(session, atMs)) / 1000))
+  return Math.round(movingMsAt(session, atMs) / 1000)
+}
+
+/**
+ * Metres a sample's speed is averaged over.
+ *
+ * Two fixes 5 m apart span under two seconds of running, and `sample.time` is
+ * stored in whole seconds, so a speed taken between neighbours is a small
+ * distance divided by a heavily quantised time — noise. Thirty metres is long
+ * enough to be stable and short enough to still show a hill.
+ */
+export const SPEED_WINDOW_M = 30
+
+/**
+ * Speed at each point, in m/s, measured on the track itself.
+ *
+ * Not `location.speed`: that is the GPS's instantaneous Doppler estimate at one
+ * moment, it is missing entirely on fixes where the OS cannot compute it, and
+ * nothing ties it to the distance and duration the activity is summarised from.
+ * The consequence was visible — an average pace that read correctly next to a
+ * pace graph that did not, because the graph averages `sample.speed` while the
+ * summary divides distance by time.
+ *
+ * Measuring it here from the same distances and the same clock makes the two
+ * agree by construction. Time is moving time in **milliseconds**: rounding to
+ * the stored second would put a ±30 % error on a two-second interval, and a
+ * pause between two fixes would otherwise read as a stop.
+ */
+export function speedSeries(session: RecordSession, cumulative: number[]): (number | undefined)[] {
+  const pts = session.points
+  return pts.map((p, i) => {
+    if (i === 0) return pts.length > 1 ? undefined : p.speed
+    // Walk back to the start of the window, or to the first point.
+    let j = i - 1
+    while (j > 0 && cumulative[i] - cumulative[j] < SPEED_WINDOW_M) j--
+    const metres = cumulative[i] - cumulative[j]
+    const seconds = (movingMsAt(session, p.time) - movingMsAt(session, pts[j].time)) / 1000
+    if (seconds <= 0) return undefined
+    return metres / seconds
+  })
 }
 
 export interface LiveStats {
@@ -143,6 +187,19 @@ export function buildActivity(session: RecordSession): {
   const pts = session.points
   const id = `recorder_${session.startTime}`
 
+  // Cumulative distance first: the speed series is measured over it.
+  const cumulative: number[] = []
+  let running = 0
+  pts.forEach((p, i) => {
+    if (i > 0) running += haversine(pts[i - 1], p)
+    cumulative.push(running)
+  })
+
+  const speeds = speedSeries(session, cumulative)
+  // The first fix has no window behind it; it borrows the one in front rather
+  // than leaving a hole at the start of every graph.
+  if (speeds.length > 1 && speeds[0] === undefined) speeds[0] = speeds[1]
+
   let dist = 0
   const samples: Sample[] = pts.map((p, i) => {
     if (i > 0) dist += haversine(pts[i - 1], p)
@@ -152,14 +209,16 @@ export function buildActivity(session: RecordSession): {
       lat: p.lat,
       lng: p.lng,
       elevation: typeof p.alt === 'number' ? p.alt : undefined,
-      speed: typeof p.speed === 'number' ? p.speed : undefined
+      speed: speeds[i]
     }
   })
 
   const distance = Math.round(dist)
   const lastPoint = pts[pts.length - 1]
   const duration = lastPoint ? movingSecondsAt(session, lastPoint.time) : 0
-  const speeds = pts.map(p => p.speed).filter((s): s is number => typeof s === 'number')
+  // From the measured series, not from raw GPS: a single Doppler spike used to
+  // be enough to file a run with an impossible top speed.
+  const measured = speeds.filter((s): s is number => typeof s === 'number')
 
   // Roughly 50 points, and always the last one: a track that stops short of
   // where the user pressed Finish reads as a lost end of run.
@@ -190,7 +249,7 @@ export function buildActivity(session: RecordSession): {
     samples,
     stats: {
       averageSpeed: duration > 0 ? distance / duration : undefined,
-      maxSpeed: speeds.length ? Math.max(...speeds) : undefined,
+      maxSpeed: measured.length ? Math.max(...measured) : undefined,
       totalAscent: totalAscent(pts) || undefined
     },
     version: 1,

--- a/plugins/storage-providers/GDrive/client/GDriveSetup.vue
+++ b/plugins/storage-providers/GDrive/client/GDriveSetup.vue
@@ -100,6 +100,10 @@
         Connexion
       </button>
     </div>
+
+    <p v-if="signInError" class="text-sm text-center text-red-600">
+      <i class="fas fa-triangle-exclamation" aria-hidden="true"></i> {{ signInError }}
+    </p>
   </div>
 </template>
 
@@ -124,13 +128,30 @@ let googleDriveFileService: GoogleDriveFileService | null = null
 const isConnected = ref(0) // 0 = pending, 1 = connected, -1 = disconnected
 const backupFilePresent = ref(0) // 0 = pending, 1 = present, -1 = not present
 
+const signInError = ref('')
+
 const oauthSignIn = async () => {
   if (!googleDriveAuthService) return
-  const uri = await googleDriveAuthService.getOauthSignInUri()
-  if (uri) {
-    window.location.href = uri
-  } else {
-    console.error('Failed to get OAuth sign-in URI')
+  signInError.value = ''
+  try {
+    // On native this returns having already exchanged the code: the sign-in
+    // happens in a system browser and comes back through a deep link, because
+    // Google refuses its sign-in page inside an embedded WebView. On the web
+    // nothing changes — the page navigates away and comes back with a ?code=.
+    const { handled, url } = await googleDriveAuthService.signIn()
+    if (handled) {
+      await refreshConnectionState()
+      return
+    }
+    if (url) window.location.href = url
+    else signInError.value = t('gdrive.signInUnavailable')
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    if (reason === 'cancelled') return
+    signInError.value =
+      reason === 'VITE_GOOGLE_NATIVE_CLIENT_ID is not set'
+        ? t('gdrive.signInUnavailable')
+        : t('gdrive.signInFailed', { message: reason })
   }
 }
 
@@ -176,6 +197,16 @@ const disconnectGoogleDrive = async () => {
   isConnected.value = -1
 }
 
+/** Read the connection state from a token, and pick up the backup file with it. */
+async function refreshConnectionState(accessToken?: string | null) {
+  const token = accessToken ?? (await googleDriveAuthService?.getAccessToken())
+  isConnected.value = token ? 1 : -1
+  if (isConnected.value !== 1) return
+
+  googleDriveFileService = await GoogleDriveFileService.getInstance()
+  backupFilePresent.value = (await googleDriveFileService.ensureBackupFile('backup.json')) ? 1 : -1
+}
+
 onMounted(async () => {
   googleDriveAuthService = await GoogleDriveAuthService.getInstance()
 
@@ -187,20 +218,6 @@ onMounted(async () => {
     accessToken = await googleDriveAuthService.getAccessTokenFromCode(code)
   }
 
-  if (accessToken) {
-    isConnected.value = 1
-  } else {
-    isConnected.value = -1
-  }
-
-  if (isConnected.value == 1) {
-    googleDriveFileService = await GoogleDriveFileService.getInstance()
-    const file = await googleDriveFileService.ensureBackupFile('backup.json')
-    if (file) {
-      backupFilePresent.value = 1
-    } else {
-      backupFilePresent.value = -1
-    }
-  }
+  await refreshConnectionState(accessToken)
 })
 </script>

--- a/plugins/storage-providers/GDrive/client/GoogleDriveAuthService.ts
+++ b/plugins/storage-providers/GDrive/client/GoogleDriveAuthService.ts
@@ -1,6 +1,7 @@
 // plugins/storage-providers/GDrive/client/GoogleDriveAuthService.ts
 import { getPluginContext } from '@/services/PluginContextFactory'
 import type { IPluginStorageService } from '@/types/plugin-context'
+import type { INativeShell } from '@/services/NativeShellService'
 import { generateCodeChallenge, generateRandomString } from './pkceUtils'
 
 // OAuth Client type: Web application (exige client_secret même avec PKCE)
@@ -12,13 +13,30 @@ const CLIENT_SECRET = import.meta.env.VITE_GOOGLE_CLIENT_SECRET
 // Pour sécurité maximale sans secret, il faudrait un backend proxy
 // Actuellement : secret dans .env (pas hardcodé, pas committé, rotatable)
 
+/**
+ * The native app talks to Google as a *different* OAuth client.
+ *
+ * It has to. A Web client only accepts http(s) redirect URIs, and the native
+ * shell has no origin worth redirecting to — it is served from
+ * `https://localhost`, which no console will ever list. A native client
+ * redirects to a custom scheme instead, and carries no secret: there is nowhere
+ * to hide one in an APK, which is why Google does not issue one for this
+ * client type. PKCE is what stands in for it, and this service already does
+ * PKCE for the web.
+ */
+const NATIVE_CLIENT_ID = import.meta.env.VITE_GOOGLE_NATIVE_CLIENT_ID
+
 const AUTHORIZATION_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
 const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
 const SCOPE = 'https://www.googleapis.com/auth/drive.file'
 
+/** Raised when the native build was shipped without its own OAuth client. */
+export class MissingNativeClientError extends Error {}
+
 export class GoogleDriveAuthService {
   private static instance: GoogleDriveAuthService
   private dbService: IPluginStorageService | null = null
+  private shell: INativeShell | null = null
   // Dedup concurrent silent refreshes so a burst of Drive calls with an expired
   // token results in ONE token POST, not one per call.
   private refreshInFlight: Promise<string | null> | null = null
@@ -41,6 +59,43 @@ export class GoogleDriveAuthService {
   private async initialize() {
     const ctx = await getPluginContext()
     this.dbService = ctx.storage
+    this.shell = ctx.shell
+  }
+
+  /** True once the app runs in the native shell, where the web flow cannot work. */
+  private get isNative(): boolean {
+    return this.shell?.isNative ?? false
+  }
+
+  /** The client this platform authenticates as. */
+  private get clientId(): string {
+    if (!this.isNative) return CLIENT_ID
+    if (!NATIVE_CLIENT_ID) {
+      throw new MissingNativeClientError('VITE_GOOGLE_NATIVE_CLIENT_ID is not set')
+    }
+    return NATIVE_CLIENT_ID
+  }
+
+  /**
+   * Where Google sends the user back.
+   *
+   * On the web, the page that started the flow. On native, a custom scheme the
+   * OS routes back into the app — the WebView's own `location.origin` is
+   * `https://localhost`, which is not a redirect target anyone has registered.
+   */
+  private get redirectUri(): string {
+    const native = this.shell?.oauthRedirectUri(this.clientId)
+    return native ?? `${window.location.origin}${window.location.pathname}`
+  }
+
+  /**
+   * A native client has no secret — Google does not issue one, because an APK
+   * cannot keep it. PKCE carries the proof instead.
+   */
+  private credentials(): Record<string, string> {
+    return this.isNative
+      ? { client_id: this.clientId }
+      : { client_id: CLIENT_ID, client_secret: CLIENT_SECRET }
   }
 
   async getAccessToken(): Promise<string | null> {
@@ -83,8 +138,7 @@ export class GoogleDriveAuthService {
             'Content-Type': 'application/x-www-form-urlencoded'
           },
           body: new URLSearchParams({
-            client_id: CLIENT_ID,
-            client_secret: CLIENT_SECRET,
+            ...this.credentials(),
             refresh_token: refreshToken,
             grant_type: 'refresh_token'
           })
@@ -140,10 +194,9 @@ export class GoogleDriveAuthService {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
       body: new URLSearchParams({
+        ...this.credentials(),
         code: code,
-        client_id: CLIENT_ID,
-        client_secret: CLIENT_SECRET,
-        redirect_uri: `${window.location.origin}${window.location.pathname}`,
+        redirect_uri: this.redirectUri,
         grant_type: 'authorization_code',
         code_verifier: code_verifier
       })
@@ -184,12 +237,11 @@ export class GoogleDriveAuthService {
 
     // Hash and base64-urlencode the secret to use as the challenge
     const code_challenge = await generateCodeChallenge(code_verifier)
-    console.log('redirect_uri', `${window.location.origin}${window.location.pathname}`)
     const url =
       AUTHORIZATION_ENDPOINT +
       '?response_type=code' +
       '&client_id=' +
-      encodeURIComponent(CLIENT_ID) +
+      encodeURIComponent(this.clientId) +
       '&state=' +
       encodeURIComponent(state) +
       '&access_type=offline' +
@@ -197,12 +249,46 @@ export class GoogleDriveAuthService {
       '&scope=' +
       encodeURIComponent(SCOPE) +
       '&redirect_uri=' +
-      encodeURIComponent(`${window.location.origin}${window.location.pathname}`) +
+      encodeURIComponent(this.redirectUri) +
       '&code_challenge=' +
       encodeURIComponent(code_challenge) +
       '&code_challenge_method=S256'
     // Redirect to the authorization server
     return url
+  }
+
+  /**
+   * Sign in the way this platform can.
+   *
+   * On the web the page navigates away and the answer arrives as a `?code=` on
+   * the way back, so this resolves to null and the caller redirects. On native
+   * there is no navigating away — the authorization happens in a system browser
+   * and the code comes back through a deep link, so the whole exchange finishes
+   * here and this resolves to an access token.
+   */
+  async signIn(): Promise<{ handled: boolean; url?: string }> {
+    const url = await this.getOauthSignInUri()
+    if (!url) return { handled: false }
+    if (!this.isNative || !this.shell) return { handled: false, url }
+
+    const scheme = this.shell.oauthRedirectUri(this.clientId)
+    if (!scheme) return { handled: false, url }
+
+    const callback = await this.shell.authorize(url, scheme)
+    const params = new URL(callback).searchParams
+
+    // Any app on the device can fire our custom scheme, so the deep link is the
+    // one step of this flow that an outsider can reach. `state` is what says the
+    // answer belongs to the request we made.
+    if (params.get('state') !== localStorage.getItem('pkce_state')) {
+      throw new Error('state_mismatch')
+    }
+
+    const code = params.get('code')
+    if (!code) throw new Error(params.get('error') ?? 'no_code')
+
+    await this.getAccessTokenFromCode(code)
+    return { handled: true }
   }
 
   async disconnect() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -907,6 +907,10 @@
       "label": "Records and rankings",
       "description": "Shows your personal bests and how each outing ranks against the rest."
     },
+    "firebase-notifications": {
+      "label": "Push notifications",
+      "description": "Get notified when new activities are imported."
+    },
     "goals": {
       "label": "Training goals",
       "description": "Set weekly or monthly goals and follow your progress live."
@@ -923,6 +927,10 @@
       "label": "Sharing and privacy",
       "description": "Manages your sharing settings and the publication of your public profile."
     },
+    "recorder-quick-action": {
+      "label": "Quick record",
+      "description": "Start, pause and finish a GPS recording straight from the home screen."
+    },
     "standard-details": {
       "label": "Activity detail",
       "description": "Heart rate, cadence, speed graphs and zones for each outing."
@@ -930,10 +938,10 @@
     "statistics": {
       "label": "Statistics",
       "description": "Trends, distributions, personal records and an activity calendar."
-    },
-    "firebase-notifications": {
-      "label": "Push notifications",
-      "description": "Get notified when new activities are imported."
     }
+  },
+  "recorderQuickAction": {
+    "title": "Record an activity",
+    "paused": "Paused"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -706,7 +706,9 @@
   },
   "gdrive": {
     "checking": "Checking the Google Drive connection...",
-    "verifying": "Checking..."
+    "verifying": "Checking...",
+    "signInFailed": "Google sign-in failed: {message}",
+    "signInUnavailable": "This build cannot sign in to Google. It ships without the OAuth client the native app needs."
   },
   "legal": {
     "privacyPolicy": "Privacy Policy",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -907,6 +907,10 @@
       "label": "Records et classements",
       "description": "Affiche vos meilleures performances et votre classement sur l'ensemble de vos sorties."
     },
+    "firebase-notifications": {
+      "label": "Notifications push",
+      "description": "Recevez une notification quand de nouvelles activités sont importées."
+    },
     "goals": {
       "label": "Objectifs d'entraînement",
       "description": "Fixez des objectifs hebdomadaires ou mensuels et suivez leur progression en direct."
@@ -923,6 +927,10 @@
       "label": "Partage et confidentialité",
       "description": "Gère vos réglages de partage et la publication de votre profil public."
     },
+    "recorder-quick-action": {
+      "label": "Enregistrement rapide",
+      "description": "Démarre, met en pause et termine un enregistrement GPS directement depuis l'accueil."
+    },
     "standard-details": {
       "label": "Détail des activités",
       "description": "Graphiques de fréquence cardiaque, cadence, vitesse et zones pour chaque sortie."
@@ -930,10 +938,10 @@
     "statistics": {
       "label": "Statistiques",
       "description": "Tendances, répartitions, records personnels et calendrier d'activité."
-    },
-    "firebase-notifications": {
-      "label": "Notifications push",
-      "description": "Recevez une notification quand de nouvelles activités sont importées."
     }
+  },
+  "recorderQuickAction": {
+    "title": "Enregistrer une activité",
+    "paused": "En pause"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -706,7 +706,9 @@
   },
   "gdrive": {
     "checking": "Vérification de la connexion à Google Drive...",
-    "verifying": "Vérification en cours..."
+    "verifying": "Vérification en cours...",
+    "signInFailed": "La connexion à Google a échoué : {message}",
+    "signInUnavailable": "Cette version ne peut pas se connecter à Google : elle est livrée sans le client OAuth dont l'application native a besoin."
   },
   "legal": {
     "privacyPolicy": "Politique de confidentialité",

--- a/src/services/AppExtensionPluginManager.ts
+++ b/src/services/AppExtensionPluginManager.ts
@@ -17,7 +17,11 @@ export class AppExtensionPluginManager extends PluginManagerBase<ExtensionPlugin
     'aggregated-details',
     'profile-sharing',
     'goals',
-    'statistics'
+    'statistics',
+    // On by default because it shows nothing until the recorder provider is
+    // connected, and only on a native build. Off by default would mean
+    // enabling two plugins to get one feature.
+    'recorder-quick-action'
   ]
 
   private constructor() {

--- a/src/services/NativeShellService.ts
+++ b/src/services/NativeShellService.ts
@@ -1,0 +1,129 @@
+/**
+ * What the native shell can do that a browser tab cannot — and what it cannot
+ * do that a browser tab can.
+ *
+ * The second half is the reason this exists. An OAuth redirect flow assumes two
+ * things a Capacitor WebView does not provide:
+ *
+ * 1. **A real origin.** With `androidScheme: "https"` the app is served from
+ *    `https://localhost`, so every `redirect_uri` built from
+ *    `window.location.origin` is a URI no provider has ever heard of —
+ *    `Error 400: redirect_uri_mismatch`.
+ * 2. **A browser Google will talk to.** Google refuses its sign-in page inside
+ *    an embedded WebView (`disallowed_useragent`, "this app may not be
+ *    secure"). That is policy, not configuration: no redirect URI makes
+ *    navigating the WebView to `accounts.google.com` work.
+ *
+ * So on native the authorization step leaves the app entirely — a Custom Tab on
+ * Android, `SFSafariViewController` on iOS — and comes back through a deep link
+ * on a custom scheme. `authorize()` is that round trip.
+ *
+ * The two Capacitor plugins are reached through `registerPlugin`, not through
+ * an import of their packages: they are installed only in the native CI build,
+ * and an import of a package the web build cannot resolve is exactly the bug
+ * that kept the GPS recorder from ever starting (see
+ * `docs/plans/CAPACITOR_GEOLOCATION.md`).
+ */
+
+import { Capacitor, registerPlugin } from '@capacitor/core'
+
+interface BrowserPlugin {
+  open(options: { url: string }): Promise<void>
+  close(): Promise<void>
+  addListener(event: 'browserFinished', cb: () => void): Promise<{ remove: () => Promise<void> }>
+}
+
+interface AppPlugin {
+  addListener(
+    event: 'appUrlOpen',
+    cb: (data: { url: string }) => void
+  ): Promise<{ remove: () => Promise<void> }>
+}
+
+const Browser = registerPlugin<BrowserPlugin>('Browser')
+const App = registerPlugin<AppPlugin>('App')
+
+/** The path a provider redirects back to, appended to the custom scheme. */
+const REDIRECT_PATH = '/oauth2redirect'
+
+/**
+ * Google identifies a native client by the reverse of its client id, and only
+ * accepts a custom-scheme redirect built from it:
+ * `123-abc.apps.googleusercontent.com` → `com.googleusercontent.apps.123-abc`.
+ */
+export function reversedClientId(clientId: string): string {
+  return clientId.split('.').reverse().join('.')
+}
+
+export interface INativeShell {
+  /** Running inside the native shell rather than a browser. */
+  readonly isNative: boolean
+
+  /**
+   * The redirect URI a native OAuth client must use, or null on the web, where
+   * the caller's own origin is a perfectly good redirect target.
+   */
+  oauthRedirectUri(clientId: string): string | null
+
+  /**
+   * Send the user to the system browser to authorize, and resolve with the
+   * callback URL the provider deep-links back to.
+   *
+   * Rejects if the user closes the browser without finishing — a cancelled
+   * sign-in has to be a rejected promise, not a promise that never settles.
+   */
+  authorize(url: string, redirectScheme: string): Promise<string>
+}
+
+export const nativeShell: INativeShell = {
+  get isNative() {
+    return Capacitor.isNativePlatform()
+  },
+
+  oauthRedirectUri(clientId: string): string | null {
+    if (!Capacitor.isNativePlatform()) return null
+    return `${reversedClientId(clientId)}:${REDIRECT_PATH}`
+  },
+
+  async authorize(url: string, redirectScheme: string): Promise<string> {
+    let resolveCallback!: (callbackUrl: string) => void
+    let rejectCallback!: (reason: Error) => void
+    const callback = new Promise<string>((resolve, reject) => {
+      resolveCallback = resolve
+      rejectCallback = reject
+    })
+    let settled = false
+
+    // Subscribed before the browser opens: a fast provider can deep-link back
+    // before `open()` has even resolved.
+    const urlListener = await App.addListener('appUrlOpen', ({ url: incoming }) => {
+      if (settled || !incoming.startsWith(redirectScheme)) return
+      settled = true
+      resolveCallback(incoming)
+      void Browser.close().catch(() => {
+        // Already gone — the OS closed the tab when it followed the deep link.
+      })
+    })
+    const closeListener = await Browser.addListener('browserFinished', () => {
+      // Fires on our own close() too, so it only means "the user gave up" while
+      // no callback has arrived.
+      if (settled) return
+      settled = true
+      rejectCallback(new Error('cancelled'))
+    })
+
+    try {
+      await Browser.open({ url })
+      return await callback
+    } finally {
+      // A listener the bridge has already dropped is not a failure worth
+      // propagating over the token we just went to fetch.
+      await urlListener.remove().catch(() => {
+        /* already gone */
+      })
+      await closeListener.remove().catch(() => {
+        /* already gone */
+      })
+    }
+  }
+}

--- a/src/services/PluginContextFactory.ts
+++ b/src/services/PluginContextFactory.ts
@@ -1,6 +1,7 @@
 import type { PluginContext, ProviderImportEvent } from '@/types/plugin-context'
 import { getActivityService } from './ActivityService'
 import { IndexedDBService } from './IndexedDBService'
+import { nativeShell } from './NativeShellService'
 import { ToastService } from './ToastService'
 import { aggregationService } from './AggregationService'
 import { FriendService } from './FriendService'
@@ -140,7 +141,9 @@ export async function createPluginContext(): Promise<PluginContext> {
         service.emitter.addEventListener('provider-activities-imported', listener)
         return () => service.emitter.removeEventListener('provider-activities-imported', listener)
       }
-    }
+    },
+
+    shell: nativeShell
   }
 }
 

--- a/src/types/plugin-context.ts
+++ b/src/types/plugin-context.ts
@@ -1,6 +1,7 @@
 import type { Activity, ActivityDetails, Sample } from './activity'
 import type { Converted, Dimension, Formatted, UnitSystem } from './units'
 import type { SegmentSample, ElevationProfile } from '@/services/ActivityAnalyzer'
+import type { INativeShell } from '@/services/NativeShellService'
 import type {
   AggregationPeriod,
   AggregatedRecord,
@@ -300,6 +301,7 @@ export interface PluginContext {
   sync: ISyncService
   units: IUnitsService
   providers: IDataProviderEvents
+  shell: INativeShell
 }
 
 /**

--- a/tests/unit/GDriveNativeAuth.spec.ts
+++ b/tests/unit/GDriveNativeAuth.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * The native app must talk to Google as a different OAuth client than the web
+ * app, and reach it through a different door. Both were assumptions the web
+ * build could make and the APK could not:
+ *
+ * - `window.location.origin` is `https://localhost` in the WebView, so a
+ *   redirect_uri built from it is one no console has ever listed;
+ * - a Web OAuth client only accepts http(s) redirects, and carries a secret an
+ *   APK cannot keep.
+ */
+
+const store = new Map<string, unknown>()
+const isNative = { value: false }
+
+const shell = {
+  get isNative() {
+    return isNative.value
+  },
+  oauthRedirectUri: (clientId: string) =>
+    isNative.value ? `${clientId.split('.').reverse().join('.')}:/oauth2redirect` : null,
+  authorize: vi.fn()
+}
+
+vi.mock('@/services/PluginContextFactory', () => ({
+  getPluginContext: async () => ({
+    storage: {
+      getData: async (k: string) => store.get(k),
+      saveData: async (k: string, v: unknown) => void store.set(k, v),
+      deleteData: async (k: string) => void store.delete(k),
+      importFromRemote: async () => {}
+    },
+    shell
+  })
+}))
+
+const WEB_CLIENT = 'web-1.apps.googleusercontent.com'
+const NATIVE_CLIENT = 'native-9.apps.googleusercontent.com'
+
+type AuthModule = typeof import('@plugins/storage-providers/GDrive/client/GoogleDriveAuthService')
+
+async function loadService(native: boolean) {
+  isNative.value = native
+  vi.resetModules()
+  const mod: AuthModule =
+    await import('@plugins/storage-providers/GDrive/client/GoogleDriveAuthService')
+  return mod.GoogleDriveAuthService.getInstance()
+}
+
+function paramsOf(url: string) {
+  return new URL(url).searchParams
+}
+
+describe('Drive sign-in URL', () => {
+  beforeEach(() => {
+    store.clear()
+    localStorage.clear()
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', WEB_CLIENT)
+    vi.stubEnv('VITE_GOOGLE_CLIENT_SECRET', 'web-secret')
+    vi.stubEnv('VITE_GOOGLE_NATIVE_CLIENT_ID', NATIVE_CLIENT)
+    shell.authorize.mockReset()
+  })
+
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('redirects to the page origin on the web', async () => {
+    const service = await loadService(false)
+    const params = paramsOf((await service.getOauthSignInUri()) as string)
+
+    expect(params.get('client_id')).toBe(WEB_CLIENT)
+    expect(params.get('redirect_uri')).toBe(`${window.location.origin}${window.location.pathname}`)
+  })
+
+  it('redirects to the custom scheme on native, never to the WebView origin', async () => {
+    const service = await loadService(true)
+    const params = paramsOf((await service.getOauthSignInUri()) as string)
+
+    expect(params.get('client_id')).toBe(NATIVE_CLIENT)
+    expect(params.get('redirect_uri')).toBe('com.googleusercontent.apps.native-9:/oauth2redirect')
+    expect(params.get('redirect_uri')).not.toContain('localhost')
+  })
+
+  it('still asks for PKCE on native, where there is no secret to send', async () => {
+    const service = await loadService(true)
+    const params = paramsOf((await service.getOauthSignInUri()) as string)
+
+    expect(params.get('code_challenge_method')).toBe('S256')
+    expect(params.get('code_challenge')).toBeTruthy()
+  })
+})
+
+describe('signIn', () => {
+  beforeEach(() => {
+    store.clear()
+    localStorage.clear()
+    vi.stubEnv('VITE_GOOGLE_CLIENT_ID', WEB_CLIENT)
+    vi.stubEnv('VITE_GOOGLE_CLIENT_SECRET', 'web-secret')
+    vi.stubEnv('VITE_GOOGLE_NATIVE_CLIENT_ID', NATIVE_CLIENT)
+    shell.authorize.mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('hands the web caller a URL to navigate to, and does nothing else', async () => {
+    const service = await loadService(false)
+    const result = await service.signIn()
+
+    expect(result.handled).toBe(false)
+    expect(result.url).toContain('accounts.google.com')
+    expect(shell.authorize).not.toHaveBeenCalled()
+  })
+
+  it('runs the whole exchange on native, and posts no client_secret', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'at', refresh_token: 'rt', expires_in: 3600 })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const service = await loadService(true)
+    shell.authorize.mockImplementation(async () => {
+      const state = localStorage.getItem('pkce_state')
+      return `com.googleusercontent.apps.native-9:/oauth2redirect?code=the-code&state=${state}`
+    })
+
+    const result = await service.signIn()
+    expect(result.handled).toBe(true)
+
+    const body = fetchMock.mock.calls[0][1].body as URLSearchParams
+    expect(body.get('code')).toBe('the-code')
+    expect(body.get('client_id')).toBe(NATIVE_CLIENT)
+    expect(body.get('client_secret')).toBeNull()
+    expect(body.get('code_verifier')).toBeTruthy()
+    expect(store.get('gdrive_refresh_token')).toBe('rt')
+  })
+
+  it('refuses a callback whose state is not the one it sent', async () => {
+    const service = await loadService(true)
+    shell.authorize.mockResolvedValue(
+      'com.googleusercontent.apps.native-9:/oauth2redirect?code=x&state=forged'
+    )
+
+    await expect(service.signIn()).rejects.toThrow('state_mismatch')
+  })
+
+  it('surfaces the provider error when no code comes back', async () => {
+    const service = await loadService(true)
+    shell.authorize.mockImplementation(async () => {
+      const state = localStorage.getItem('pkce_state')
+      return `com.googleusercontent.apps.native-9:/oauth2redirect?error=access_denied&state=${state}`
+    })
+
+    await expect(service.signIn()).rejects.toThrow('access_denied')
+  })
+
+  it('says so rather than guessing when the build has no native client', async () => {
+    vi.stubEnv('VITE_GOOGLE_NATIVE_CLIENT_ID', '')
+    const service = await loadService(true)
+
+    await expect(service.signIn()).rejects.toThrow('VITE_GOOGLE_NATIVE_CLIENT_ID is not set')
+  })
+})

--- a/tests/unit/NativeShellService.spec.ts
+++ b/tests/unit/NativeShellService.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const isNativePlatform = vi.fn(() => false)
+const open = vi.fn().mockResolvedValue(undefined)
+const close = vi.fn().mockResolvedValue(undefined)
+const listeners: Record<string, (payload: never) => void> = {}
+const remove = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => isNativePlatform() },
+  registerPlugin: (name: string) => {
+    if (name === 'Browser') {
+      return {
+        open,
+        close,
+        addListener: async (event: string, cb: (p: never) => void) => {
+          listeners[`Browser:${event}`] = cb
+          return { remove }
+        }
+      }
+    }
+    return {
+      addListener: async (event: string, cb: (p: never) => void) => {
+        listeners[`App:${event}`] = cb
+        return { remove }
+      }
+    }
+  }
+}))
+
+const { nativeShell, reversedClientId } = await import('@/services/NativeShellService')
+
+const CLIENT = '123-abc.apps.googleusercontent.com'
+const SCHEME = 'com.googleusercontent.apps.123-abc'
+
+/** Wait for the service to have subscribed before firing an event at it. */
+async function settled() {
+  for (let i = 0; i < 10; i++) await Promise.resolve()
+}
+
+describe('reversedClientId', () => {
+  it('builds the only redirect shape Google accepts for a native client', () => {
+    expect(reversedClientId(CLIENT)).toBe(SCHEME)
+  })
+})
+
+describe('oauthRedirectUri', () => {
+  beforeEach(() => isNativePlatform.mockReturnValue(false))
+
+  it('is null on the web, where the page origin is a fine redirect target', () => {
+    expect(nativeShell.oauthRedirectUri(CLIENT)).toBeNull()
+  })
+
+  it('is the custom scheme on native, never the WebView origin', () => {
+    isNativePlatform.mockReturnValue(true)
+    const uri = nativeShell.oauthRedirectUri(CLIENT)
+    expect(uri).toBe(`${SCHEME}:/oauth2redirect`)
+    // https://localhost is what window.location.origin would have given, and it
+    // is exactly the value that produced redirect_uri_mismatch.
+    expect(uri).not.toContain('localhost')
+  })
+})
+
+describe('authorize', () => {
+  beforeEach(() => {
+    isNativePlatform.mockReturnValue(true)
+    open.mockClear()
+    close.mockClear()
+    remove.mockClear()
+  })
+
+  it('sends the user to the system browser, not the WebView', async () => {
+    const pending = nativeShell.authorize('https://accounts.google.com/o/oauth2/v2/auth', SCHEME)
+    await settled()
+
+    expect(open).toHaveBeenCalledWith({ url: 'https://accounts.google.com/o/oauth2/v2/auth' })
+
+    listeners['App:appUrlOpen']({ url: `${SCHEME}:/oauth2redirect?code=abc&state=xyz` } as never)
+    await expect(pending).resolves.toContain('code=abc')
+  })
+
+  it('closes the browser once the callback lands', async () => {
+    const pending = nativeShell.authorize('https://auth', SCHEME)
+    await settled()
+    listeners['App:appUrlOpen']({ url: `${SCHEME}:/oauth2redirect?code=abc` } as never)
+    await pending
+
+    expect(close).toHaveBeenCalled()
+  })
+
+  it('ignores a deep link meant for something else', async () => {
+    const pending = nativeShell.authorize('https://auth', SCHEME)
+    await settled()
+
+    listeners['App:appUrlOpen']({ url: 'app.openstride://something-else' } as never)
+    await settled()
+    expect(close).not.toHaveBeenCalled()
+
+    listeners['App:appUrlOpen']({ url: `${SCHEME}:/oauth2redirect?code=ok` } as never)
+    await expect(pending).resolves.toContain('code=ok')
+  })
+
+  it('rejects when the user closes the browser instead of signing in', async () => {
+    const pending = nativeShell.authorize('https://auth', SCHEME)
+    await settled()
+
+    listeners['Browser:browserFinished'](undefined as never)
+    await expect(pending).rejects.toThrow('cancelled')
+  })
+
+  it('lets go of its listeners either way', async () => {
+    const pending = nativeShell.authorize('https://auth', SCHEME)
+    await settled()
+    listeners['App:appUrlOpen']({ url: `${SCHEME}:/oauth2redirect?code=ok` } as never)
+    await pending
+
+    expect(remove).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/plugins/Recorder.spec.ts
+++ b/tests/unit/plugins/Recorder.spec.ts
@@ -155,6 +155,89 @@ describe('buildActivity', () => {
   })
 })
 
+/**
+ * The complaint that produced these: on a real recording the average pace read
+ * correctly while the pace graph was nonsense. They came from two unrelated
+ * quantities — the summary divides distance by duration, the graph averages
+ * `sample.speed`, which used to be the GPS's own instantaneous estimate.
+ */
+describe('the pace a sample reports agrees with the pace of the activity', () => {
+  /** A run at a steady `mps`, fixes every `everyM` metres, as the watcher sees it. */
+  function steadyRun(mps: number, everyM: number, metres: number): RecordSession {
+    const points: GeoPoint[] = []
+    for (let d = 0; d <= metres; d += everyM) {
+      // Whatever the device says about speed is deliberately absurd here: the
+      // recording must not depend on it.
+      points.push(point(d / mps, d, { speed: 99 }))
+    }
+    return { ...emptySession('running'), startTime: T0, points }
+  }
+
+  it('reports the true speed on every sample of a steady run', () => {
+    const { activity, details } = buildActivity(steadyRun(3, 5, 1000))
+    const samples = details.samples ?? []
+
+    expect(activity.distance / activity.duration).toBeCloseTo(3, 1)
+    for (const s of samples) {
+      expect(s.speed, `sample at ${s.distance} m`).toBeCloseTo(3, 1)
+    }
+  })
+
+  it('never repeats what the GPS claimed about speed', () => {
+    const { details } = buildActivity(steadyRun(3, 5, 200))
+    expect((details.samples ?? []).some(s => s.speed === 99)).toBe(false)
+    expect(details.stats?.maxSpeed).toBeLessThan(10)
+  })
+
+  it('survives fixes closer together than the stored one-second resolution', () => {
+    // 5 m at 3 m/s is 1.67 s — rounded to whole seconds that is a ±30 % error,
+    // which is precisely what made neighbouring samples disagree wildly.
+    const { details } = buildActivity(steadyRun(3, 5, 300))
+    const speeds = (details.samples ?? []).map(s => s.speed ?? 0)
+    const spread = Math.max(...speeds) - Math.min(...speeds)
+    expect(spread).toBeLessThan(0.5)
+  })
+
+  it('does not read a pause as a collapse in speed', () => {
+    // Two 200 m halves at 3 m/s with a ten-minute pause in between.
+    const points: GeoPoint[] = []
+    for (let d = 0; d <= 200; d += 5) points.push(point(d / 3, d))
+    for (let d = 205; d <= 400; d += 5) points.push(point(600 + d / 3, d))
+    const session: RecordSession = {
+      ...emptySession('running'),
+      startTime: T0,
+      pauses: [{ start: T0 + (200 / 3) * 1000, end: T0 + 600_000 + (200 / 3) * 1000 }],
+      points
+    }
+
+    const { details } = buildActivity(session)
+    for (const s of details.samples ?? []) {
+      if (s.speed !== undefined) expect(s.speed, `at ${s.distance} m`).toBeCloseTo(3, 1)
+    }
+  })
+
+  it('follows a change of pace instead of smoothing it away', () => {
+    // 300 m at 4 m/s, then 300 m at 2 m/s.
+    const points: GeoPoint[] = []
+    for (let d = 0; d <= 300; d += 5) points.push(point(d / 4, d))
+    for (let d = 305; d <= 600; d += 5) points.push(point(75 + (d - 300) / 2, d))
+    const session: RecordSession = { ...emptySession('running'), startTime: T0, points }
+
+    const samples = buildActivity(session).details.samples ?? []
+    // Nearest, not exact: haversine over the synthetic track lands a metre or
+    // two off the round numbers the points were laid out on.
+    const at = (metres: number) =>
+      samples.reduce((best, s) =>
+        Math.abs((s.distance ?? 0) - metres) < Math.abs((best.distance ?? 0) - metres) ? s : best
+      )
+    const fast = at(200)
+    const slow = at(500)
+
+    expect(fast?.speed).toBeCloseTo(4, 1)
+    expect(slow?.speed).toBeCloseTo(2, 1)
+  })
+})
+
 describe('movingSecondsAt', () => {
   it('never goes negative for a point before the start', () => {
     const session: RecordSession = { ...emptySession(), startTime: T0, points: [] }

--- a/tests/unit/plugins/RecorderQuickAction.spec.ts
+++ b/tests/unit/plugins/RecorderQuickAction.spec.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/locales/en.json'
+import { PLUGIN_CONTEXT_KEY } from '@/composables/usePluginContext'
+import * as recorder from '@plugins/data-providers/RecorderProvider/client/session'
+import RecorderQuickAction from '@plugins/app-extensions/RecorderQuickAction/RecorderQuickAction.vue'
+
+const startWatch = vi.fn().mockResolvedValue('watcher-1')
+const stopWatch = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@plugins/data-providers/RecorderProvider/client/geo', () => ({
+  NOT_AUTHORIZED: 'NOT_AUTHORIZED',
+  startWatch: (...a: unknown[]) => startWatch(...a),
+  stopWatch: (...a: unknown[]) => stopWatch(...a),
+  openLocationSettings: vi.fn()
+}))
+
+const store = new Map<string, unknown>()
+const saveActivityWithDetails = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('@/services/PluginContextFactory', () => ({
+  getPluginContext: async () => ({
+    storage: {
+      getData: async (k: string) => store.get(k),
+      saveData: async (k: string, v: unknown) => void store.set(k, v),
+      deleteData: async (k: string) => void store.delete(k)
+    },
+    activity: { saveActivityWithDetails }
+  })
+}))
+
+const isPluginActive = vi.fn().mockResolvedValue(true)
+const notify = vi.fn()
+
+const ctx = {
+  storage: {
+    getData: async (k: string) => store.get(k),
+    saveData: async (k: string, v: unknown) => void store.set(k, v),
+    deleteData: async (k: string) => void store.delete(k)
+  },
+  plugins: { isPluginActive },
+  notifications: { notify },
+  units: { format: (_d: string, si: number) => ({ text: `${(si / 1000).toFixed(2)} km` }) }
+}
+
+const i18n = createI18n({ legacy: false, locale: 'en', messages: { en } })
+
+function render() {
+  return mount(RecorderQuickAction, {
+    global: { plugins: [i18n], provide: { [PLUGIN_CONTEXT_KEY]: ctx } }
+  })
+}
+
+describe('recorder quick action', () => {
+  beforeEach(() => {
+    store.clear()
+    isPluginActive.mockResolvedValue(true)
+    notify.mockClear()
+    startWatch.mockClear()
+    stopWatch.mockClear()
+    saveActivityWithDetails.mockClear()
+    recorder.resetForTests()
+  })
+
+  afterEach(() => recorder.resetForTests())
+
+  it('shows nothing while the recorder provider is switched off', async () => {
+    isPluginActive.mockResolvedValue(false)
+    const w = render()
+    await flushPromises()
+
+    expect(w.find('[data-test="recorder-quick-action"]').exists()).toBe(false)
+  })
+
+  it('offers a start button once the provider is on', async () => {
+    const w = render()
+    await flushPromises()
+
+    expect(w.find('[data-test="recorder-start"]').exists()).toBe(true)
+    expect(w.find('[data-test="recorder-finish"]').exists()).toBe(false)
+  })
+
+  it('starts a recording, and turns into the live control', async () => {
+    const w = render()
+    await flushPromises()
+
+    await w.find('[data-test="recorder-start"]').trigger('click')
+    await flushPromises()
+
+    expect(startWatch).toHaveBeenCalledTimes(1)
+    expect(recorder.state.phase).toBe('recording')
+    expect(w.find('[data-test="recorder-pause"]').exists()).toBe(true)
+    expect(w.find('[data-test="recorder-finish"]').exists()).toBe(true)
+    expect(w.find('[data-test="recorder-start"]').exists()).toBe(false)
+  })
+
+  it('pauses and resumes the same recording', async () => {
+    const w = render()
+    await flushPromises()
+    await w.find('[data-test="recorder-start"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-test="recorder-pause"]').trigger('click')
+    await flushPromises()
+    expect(recorder.state.phase).toBe('paused')
+    expect(stopWatch).toHaveBeenCalledWith('watcher-1')
+
+    await w.find('[data-test="recorder-resume"]').trigger('click')
+    await flushPromises()
+    expect(recorder.state.phase).toBe('recording')
+    expect(startWatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('says nothing was recorded when finishing without a single fix', async () => {
+    const w = render()
+    await flushPromises()
+    await w.find('[data-test="recorder-start"]').trigger('click')
+    await flushPromises()
+
+    await w.find('[data-test="recorder-finish"]').trigger('click')
+    await flushPromises()
+
+    expect(saveActivityWithDetails).not.toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith(en.providers.recorder.nothingRecorded, {
+      type: 'warning'
+    })
+    expect(recorder.state.phase).toBe('idle')
+  })
+
+  it('adopts a recording left running by the setup screen', async () => {
+    await recorder.start('cycling', { title: 't', message: 'm' })
+    const w = render()
+    await flushPromises()
+
+    // No second watcher, and the live control rather than the start button.
+    expect(startWatch).toHaveBeenCalledTimes(1)
+    expect(w.find('[data-test="recorder-finish"]').exists()).toBe(true)
+  })
+
+  it('shows the distance through the unit system, never raw metres', async () => {
+    await recorder.start('running', { title: 't', message: 'm' })
+    const onPoint = startWatch.mock.calls[0][0] as (p: unknown) => void
+    onPoint({ lat: 45, lng: 5, time: Date.now() })
+    onPoint({ lat: 45.009, lng: 5, time: Date.now() + 300_000 })
+
+    const w = render()
+    await flushPromises()
+
+    expect(w.find('[data-test="recorder-quick-action"]').text()).toContain('km')
+  })
+})


### PR DESCRIPTION
Google Drive sign-in does not work in the APK. Same family as the geolocation
bug — a web assumption the WebView does not hold — but two of them, stacked.

## What was broken

1. **`redirect_uri_mismatch`.** The redirect URI was built from
   `window.location.origin`, which in the APK is `https://localhost` (the app is
   served there, `androidScheme: "https"`). No Google console has ever heard of
   that URI, so the flow died at Google's door with `Error 400`.
2. **`disallowed_useragent`.** Even with the URI fixed, Google refuses to render
   its sign-in page inside an embedded WebView. That is policy, not
   configuration: `window.location.href = accounts.google.com/…` from inside the
   app was never going to work, whatever we register.

## The fix

On native the authorization **leaves the app**: `NativeShellService.authorize()`
opens a Custom Tab (a real browser, which satisfies Google) and waits for the
provider to deep-link back on a custom scheme. Plugins reach it through
`ctx.shell`, not by importing the service — per the plugin rules.

Both Capacitor plugins are reached with `registerPlugin` rather than an import of
their packages. That is deliberate: the web build must not have to resolve a
module that only exists in the native CI build, which is exactly what kept the
GPS recorder from ever starting.

**A native app is also a different OAuth client.** A Web client accepts only
http(s) redirects and carries a `client_secret` an APK cannot keep. The service
now picks its client id, its redirect URI and whether to send a secret from the
platform, keeping the PKCE it already did for the web. Google is strict about the
redirect shape — the reverse of the client id:

```
123-abc.apps.googleusercontent.com  →  com.googleusercontent.apps.123-abc:/oauth2redirect
```

The native callback also arrives over a scheme any app on the device can fire, so
`state` is now checked against the value we sent. The web flow never did.

## What you have to do before this works on a phone

Three things must agree, and one of them is not in this repo:

| Where | What |
| --- | --- |
| **Google Cloud Console** | create an **Android** OAuth client (package `app.openstride` + the debug keystore's SHA-1) |
| **Repo secret** | `VITE_GOOGLE_NATIVE_CLIENT_ID` = that client id |
| `AndroidManifest.xml` | the `intent-filter` — CI derives it from the secret, nothing to do |

A build without the secret still installs and runs: the Drive screen says it
cannot sign in, rather than sending the user to a redirect_uri_mismatch.

## Garmin, in passing

Same disease, different mechanism: it waits for a `postMessage` from a popup, and
Capacitor hands `window.open` to the system browser — no `opener` to answer
through, no shared `BroadcastChannel`. The popup opens, the user signs in, the app
waits forever.

Garmin does not refuse WebViews the way Google does, so on native
`connectToGarmin()` now takes the redirect path the component already carried as
its popup-blocked fallback, landing back on `https://localhost/oauth/garmin/callback`
— the app's own route. **Unverified on a device**, and it needs that redirect URI
registered in the Garmin console. If Garmin rejects `https://localhost`, the
fallback is the same custom-scheme shape as Google's.

## Verification

- **819 unit tests pass**, 16 new: `NativeShellService.spec.ts` (deep-link round
  trip, cancellation, foreign deep links, listener cleanup) and
  `GDriveNativeAuth.spec.ts` (client id / redirect URI / secret per platform,
  state mismatch, missing native client)
- `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm run build` all clean
- **Nothing here has run on a phone.** It cannot, until the Android OAuth client
  exists.

Reasoning and the remaining iOS work are written down in
`docs/plans/CAPACITOR_OAUTH.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6JuvwCEHtg2KyhdZhCAEy)_