### PR TITLE
fix(garmin): stop the PWA callback from spending the same code twice

### DIFF
--- a/plugins/data-providers/GarminProvider/client/GarminSetup.vue
+++ b/plugins/data-providers/GarminProvider/client/GarminSetup.vue
@@ -116,7 +116,19 @@ import {
   type SyncProgressEvent
 } from './GarminSyncManager'
 import { generateCodeVerifier, generateCodeChallenge, exchangeCodeForTokens } from './garminAuth'
+import {
+  saveHandshake,
+  readHandshake,
+  clearHandshake,
+  markCodeConsumed,
+  isCodeConsumed
+} from './oauthHandshake'
 import pluginEnv from './env'
+
+// Must match the authorization request byte for byte at exchange time, so it is
+// derived once and never from the page the user happens to be standing on.
+const REDIRECT_URI = `${window.location.origin}/oauth/garmin/callback`
+const OAUTH_SCOPE = 'HISTORICAL_DATA_EXPORT ACTIVITY_EXPORT'
 
 const isConnected = ref(false)
 const isRefreshing = ref(false)
@@ -142,30 +154,34 @@ const { notifications, plugins } = ctx
 const { t } = useI18n()
 
 let oauthChannel: BroadcastChannel | null = null
+// Guards against the same authorization being completed twice within this
+// instance; `isCodeConsumed` guards it across browsing contexts.
+let oauthCompleted = false
 
 // ============================================================================
 // OAuth 2.0 PKCE Flow (Popup-based)
 // ============================================================================
 
-async function connectToGarmin() {
-  // Generate PKCE verifier + challenge
+// Starts a handshake and returns the authorization URL to send the user to.
+async function startHandshake(): Promise<string> {
   const codeVerifier = generateCodeVerifier()
   const codeChallenge = await generateCodeChallenge(codeVerifier)
-  sessionStorage.setItem('garmin_pkce_verifier', codeVerifier)
-
-  // Generate CSRF state token
   const state = crypto.randomUUID()
-  sessionStorage.setItem('garmin_oauth_state', state)
+  saveHandshake(state, codeVerifier)
 
-  const redirectUri = `${window.location.origin}/oauth/garmin/callback`
-  const authUrl =
+  return (
     `${pluginEnv.garminAuthUrl}?client_id=${pluginEnv.clientId}` +
     `&response_type=code` +
     `&code_challenge=${codeChallenge}` +
     `&code_challenge_method=S256` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-    `&scope=${encodeURIComponent('HISTORICAL_DATA_EXPORT ACTIVITY_EXPORT')}` +
+    `&redirect_uri=${encodeURIComponent(REDIRECT_URI)}` +
+    `&scope=${encodeURIComponent(OAUTH_SCOPE)}` +
     `&state=${state}`
+  )
+}
+
+async function connectToGarmin() {
+  const authUrl = await startHandshake()
 
   // Open centered popup
   const width = 600
@@ -214,58 +230,87 @@ async function handleOAuthMessage(event: MessageEvent) {
   if (event.origin !== window.location.origin) return
   if (event.data?.type !== 'garmin-oauth-callback') return
 
-  // Cleanup
+  // Tell the callback window we took the handoff, before anything can throw, so
+  // it stops short of its own fallback: redirecting itself onto this page with
+  // the same code. That second pass is what used to surface as a state
+  // mismatch, right after the first pass had announced "connected".
+  ackOAuthCallback()
+
   window.removeEventListener('message', handleOAuthMessage)
   cleanupOAuthChannel()
   isWaitingForOAuth.value = false
   oauthPopup?.close()
 
-  // Validate state (CSRF protection)
-  const expectedState = sessionStorage.getItem('garmin_oauth_state')
-  if (event.data.state !== expectedState) {
+  await completeOAuth(event.data)
+}
+
+// Sends the acknowledgement on a channel of its own: a BroadcastChannel never
+// receives what it posted, so replying on `oauthChannel` would reach nobody.
+function ackOAuthCallback() {
+  try {
+    const channel = new BroadcastChannel('garmin-oauth')
+    channel.postMessage({ type: 'garmin-oauth-ack' })
+    channel.close()
+  } catch {
+    // No BroadcastChannel — the callback window falls back to redirecting, and
+    // the consumed-code guard below keeps that replay silent.
+  }
+}
+
+// Single entry point for a callback, whichever way it reached us: postMessage
+// from a popup, BroadcastChannel from a Custom Tab, or query params after a
+// redirect. All three can fire for one authorization, so this has to be safe to
+// run twice.
+async function completeOAuth(payload: {
+  code?: string | null
+  state?: string | null
+  error?: string | null
+}) {
+  const { code, state, error } = payload
+
+  if (oauthCompleted || (code && isCodeConsumed(code))) return
+
+  // CSRF protection
+  const handshake = readHandshake()
+  if (!handshake || state !== handshake.state) {
+    clearHandshake()
     notifications.notify(t('providers.notify.stateMismatch'), { type: 'error' })
     return
   }
-  sessionStorage.removeItem('garmin_oauth_state')
 
-  // Handle error from OAuth provider
-  if (event.data.error) {
-    notifications.notify(
-      t('providers.notify.generic', { provider: 'Garmin', message: event.data.error }),
-      { type: 'error' }
-    )
+  if (error) {
+    clearHandshake()
+    notifications.notify(t('providers.notify.generic', { provider: 'Garmin', message: error }), {
+      type: 'error'
+    })
     return
   }
 
-  // Exchange authorization code for tokens via Firebase proxy
-  const { code } = event.data
-  if (code) {
-    try {
-      const codeVerifier = sessionStorage.getItem('garmin_pkce_verifier')
-      if (!codeVerifier) {
-        notifications.notify(t('providers.notify.pkceMissing'), { type: 'error' })
-        return
-      }
-      sessionStorage.removeItem('garmin_pkce_verifier')
+  if (!code) return
 
-      const redirectUri = `${window.location.origin}/oauth/garmin/callback`
-      await exchangeCodeForTokens(code, codeVerifier, redirectUri)
-      isConnected.value = true
+  oauthCompleted = true
+  markCodeConsumed(code)
+  clearHandshake()
 
-      await plugins.enablePlugin('garmin')
+  try {
+    await exchangeCodeForTokens(code, handshake.verifier, REDIRECT_URI)
+    isConnected.value = true
 
-      const syncManager = getGarminSyncManager()
-      await syncManager.startInitialImportAsync()
+    await plugins.enablePlugin('garmin')
 
-      notifications.notify(t('providers.notify.connected', { provider: 'Garmin' }), {
-        type: 'info'
-      })
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Token exchange error'
-      notifications.notify(t('providers.notify.generic', { provider: 'Garmin', message }), {
-        type: 'error'
-      })
-    }
+    const syncManager = getGarminSyncManager()
+    await syncManager.startInitialImportAsync()
+
+    notifications.notify(t('providers.notify.connected', { provider: 'Garmin' }), {
+      type: 'info'
+    })
+  } catch (err: unknown) {
+    // The code is burnt either way, but the user must be able to start over.
+    oauthCompleted = false
+    const message = err instanceof Error ? err.message : 'Token exchange error'
+    notifications.notify(t('providers.notify.generic', { provider: 'Garmin', message }), {
+      type: 'error'
+    })
   }
 }
 
@@ -281,8 +326,11 @@ function handleOAuthCancelled() {
   window.removeEventListener('message', handleOAuthMessage)
   cleanupOAuthChannel()
   isWaitingForOAuth.value = false
-  sessionStorage.removeItem('garmin_oauth_state')
-  sessionStorage.removeItem('garmin_pkce_verifier')
+  // The handshake is deliberately left in place: "the window closed" is not
+  // "the user gave up". A PWA hands the authorization page to a Custom Tab
+  // whose `closed` can flip while the user is still signing in, and the answer
+  // then arrives by broadcast or redirect. Dropping the handshake here would
+  // turn that answer into a state mismatch. It expires on its own.
 }
 
 function cleanupOAuthChannel() {
@@ -293,22 +341,7 @@ function cleanupOAuthChannel() {
 }
 
 async function connectWithRedirect() {
-  const codeVerifier = generateCodeVerifier()
-  const codeChallenge = await generateCodeChallenge(codeVerifier)
-  sessionStorage.setItem('garmin_pkce_verifier', codeVerifier)
-
-  const state = crypto.randomUUID()
-  sessionStorage.setItem('garmin_oauth_state', state)
-
-  const redirectUri = `${window.location.origin}/oauth/garmin/callback`
-  window.location.href =
-    `${pluginEnv.garminAuthUrl}?client_id=${pluginEnv.clientId}` +
-    `&response_type=code` +
-    `&code_challenge=${codeChallenge}` +
-    `&code_challenge_method=S256` +
-    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-    `&scope=${encodeURIComponent('HISTORICAL_DATA_EXPORT ACTIVITY_EXPORT')}` +
-    `&state=${state}`
+  window.location.href = await startHandshake()
 }
 
 async function disconnectGarmin() {
@@ -491,47 +524,16 @@ onMounted(async () => {
     notifications.notify(message, { type: 'error' })
     window.history.replaceState({}, '', window.location.pathname)
   } else if (code && state) {
-    const expectedState = sessionStorage.getItem('garmin_oauth_state')
-    if (state !== expectedState) {
-      notifications.notify(t('providers.notify.stateMismatch'), { type: 'error' })
-      sessionStorage.removeItem('garmin_oauth_state')
-      sessionStorage.removeItem('garmin_pkce_verifier')
-    } else {
-      sessionStorage.removeItem('garmin_oauth_state')
-
-      try {
-        const codeVerifier = sessionStorage.getItem('garmin_pkce_verifier')
-        if (!codeVerifier) throw new Error('PKCE verifier missing')
-        sessionStorage.removeItem('garmin_pkce_verifier')
-
-        const redirectUri = window.location.href.split('?')[0]
-        await exchangeCodeForTokens(code, codeVerifier, redirectUri)
-        isConnected.value = true
-
-        await plugins.enablePlugin('garmin')
-
-        const syncManager = getGarminSyncManager()
-        await syncManager.startInitialImportAsync()
-
-        notifications.notify(t('providers.notify.connected', { provider: 'Garmin' }), {
-          type: 'info'
-        })
-      } catch (err: unknown) {
-        notifications.notify(
-          t('providers.notify.generic', {
-            provider: 'Garmin',
-            message: err instanceof Error ? err.message : 'Error'
-          }),
-          {
-            type: 'error'
-          }
-        )
-      }
-    }
-
+    // Strip the params before doing the work: a reload mid-exchange must not
+    // replay a code that is already spent.
     window.history.replaceState({}, '', window.location.pathname)
-  } else {
-    // Check existing tokens
+    await completeOAuth({ code, state })
+  }
+
+  // Always reconcile against the stored tokens, including after a callback we
+  // ignored as a replay: another context may have completed the exchange, and
+  // the page must still show itself as connected.
+  if (!isConnected.value) {
     const tokens = await getTokens()
     if (tokens) {
       isConnected.value = true

--- a/plugins/data-providers/GarminProvider/client/oauthHandshake.ts
+++ b/plugins/data-providers/GarminProvider/client/oauthHandshake.ts
@@ -1,0 +1,73 @@
+// State of an in-flight Garmin OAuth 2.0 PKCE handshake.
+//
+// localStorage, not sessionStorage: in a standalone PWA the authorization page is
+// not a classic popup. Android hands it to a Custom Tab and COOP nullifies
+// `window.opener` on the way back from Garmin, so the callback can land in a
+// browsing context whose sessionStorage is empty — a state written there could
+// never be matched, and every redirect fallback ended on "state mismatch".
+// localStorage is shared by every same-origin context of the profile.
+
+const HANDSHAKE_KEY = 'garmin_oauth_handshake'
+const CONSUMED_KEY = 'garmin_oauth_consumed_code'
+
+// A user who leaves the Garmin page open for longer than this restarts the flow.
+const HANDSHAKE_TTL_MS = 10 * 60 * 1000
+
+// How long a code stays flagged as already handled. Only has to outlive the
+// duplicate delivery it guards against (a callback window redirecting a second
+// later), never a real reconnection.
+const CONSUMED_TTL_MS = 60 * 1000
+
+export interface OAuthHandshake {
+  state: string
+  verifier: string
+  createdAt: number
+}
+
+function readJson<T>(key: string): T | null {
+  try {
+    const raw = localStorage.getItem(key)
+    return raw ? (JSON.parse(raw) as T) : null
+  } catch {
+    return null
+  }
+}
+
+export function saveHandshake(state: string, verifier: string): void {
+  const handshake: OAuthHandshake = { state, verifier, createdAt: Date.now() }
+  localStorage.setItem(HANDSHAKE_KEY, JSON.stringify(handshake))
+}
+
+export function readHandshake(): OAuthHandshake | null {
+  const handshake = readJson<OAuthHandshake>(HANDSHAKE_KEY)
+  if (!handshake?.state || !handshake.verifier) return null
+
+  if (Date.now() - handshake.createdAt > HANDSHAKE_TTL_MS) {
+    clearHandshake()
+    return null
+  }
+  return handshake
+}
+
+export function clearHandshake(): void {
+  localStorage.removeItem(HANDSHAKE_KEY)
+}
+
+// An authorization code is single-use. Flagging it lets a second delivery of the
+// same callback — postMessage *and* BroadcastChannel, or a callback window that
+// redirected before its acknowledgement landed — be ignored in silence instead
+// of being reported as a state mismatch the user can do nothing about.
+export function markCodeConsumed(code: string): void {
+  localStorage.setItem(CONSUMED_KEY, JSON.stringify({ code, at: Date.now() }))
+}
+
+export function isCodeConsumed(code: string): boolean {
+  const entry = readJson<{ code: string; at: number }>(CONSUMED_KEY)
+  if (!entry || entry.code !== code) return false
+
+  if (Date.now() - entry.at > CONSUMED_TTL_MS) {
+    localStorage.removeItem(CONSUMED_KEY)
+    return false
+  }
+  return true
+}

--- a/src/views/GarminOAuthCallback.vue
+++ b/src/views/GarminOAuthCallback.vue
@@ -33,6 +33,11 @@ const { t } = useI18n()
 const status = ref<'processing' | 'success' | 'error' | 'no-opener' | 'broadcast'>('processing')
 const errorMessage = ref('Authentication error')
 
+// Long enough for an app window that is merely busy to answer, short enough
+// that a user with no app window open is not left waiting on a dead screen.
+const ACK_TIMEOUT_MS = 2500
+let acknowledged = false
+
 onMounted(() => {
   const params = new URLSearchParams(window.location.search)
   const code = params.get('code')
@@ -65,7 +70,7 @@ onMounted(() => {
   if (window.opener) {
     window.opener.postMessage(payload, window.location.origin)
     status.value = error ? 'error' : 'success'
-    setTimeout(() => window.close(), 1500)
+    setTimeout(closeOrReturnToSetup, 1500)
     return
   }
 
@@ -73,32 +78,53 @@ onMounted(() => {
   // Handles the case where cross-origin navigation (Garmin OAuth) nullifies window.opener
   try {
     const channel = new BroadcastChannel('garmin-oauth')
-    channel.postMessage(payload)
-    channel.close()
 
-    if (error) {
-      status.value = 'error'
-      // Redirect to setup page with error so user sees feedback
-      setTimeout(() => {
-        const setupUrl = new URL('/data-provider/garmin', window.location.origin)
+    // The app answers if it is listening. Redirecting *and* broadcasting hands
+    // the same single-use code over twice: the app spends it, then the redirect
+    // replays it against a handshake that no longer exists — which is what
+    // reported itself as "connected", then "state mismatch".
+    channel.onmessage = (event: MessageEvent) => {
+      if (event.data?.type !== 'garmin-oauth-ack' || acknowledged) return
+      acknowledged = true
+      channel.close()
+      status.value = error ? 'error' : 'success'
+      setTimeout(closeOrReturnToSetup, 1200)
+    }
+
+    channel.postMessage(payload)
+
+    // Nobody answered — no app window open on this origin. Carry the callback
+    // over by URL, which is now the only delivery in flight.
+    setTimeout(() => {
+      if (acknowledged) return
+      channel.close()
+      status.value = error ? 'error' : 'broadcast'
+
+      const setupUrl = new URL('/data-provider/garmin', window.location.origin)
+      if (error) {
         setupUrl.searchParams.set('oauth_error', error)
-        window.location.href = setupUrl.toString()
-      }, 2000)
-    } else {
-      status.value = 'broadcast'
-      // Redirect to Garmin setup page with code+state so it can exchange for tokens
-      setTimeout(() => {
-        const setupUrl = new URL('/data-provider/garmin', window.location.origin)
+      } else {
         if (code) setupUrl.searchParams.set('code', code)
         if (state) setupUrl.searchParams.set('state', state)
-        window.location.href = setupUrl.toString()
-      }, 1500)
-    }
+      }
+      window.location.href = setupUrl.toString()
+    }, ACK_TIMEOUT_MS)
   } catch {
     // BroadcastChannel not supported — true no-opener fallback
     status.value = 'no-opener'
   }
 })
+
+function closeOrReturnToSetup() {
+  window.close()
+
+  // A tab the browser did not open through script ignores close(). Rather than
+  // strand the user on a dead callback screen, send them back to the setup
+  // page — without the OAuth params, which have already been handled.
+  setTimeout(() => {
+    window.location.href = new URL('/data-provider/garmin', window.location.origin).toString()
+  }, 600)
+}
 </script>
 
 <style scoped>

--- a/tests/e2e/specs/garmin_add_activity.cy.js
+++ b/tests/e2e/specs/garmin_add_activity.cy.js
@@ -64,10 +64,18 @@ describe('Garmin provider refresh (mock UI flow)', () => {
     // Wait for navigation to complete
     cy.url({ timeout: 10000 }).should('match', /data-provider\/garmin/)
 
-    // Pre-seed sessionStorage with OAuth state for CSRF validation
+    // Pre-seed the OAuth handshake for CSRF validation. It lives in
+    // localStorage: a PWA callback can land in a context that never saw the
+    // request start, so sessionStorage cannot carry it.
     cy.window().then(win => {
-      win.sessionStorage.setItem('garmin_oauth_state', MOCK_STATE)
-      win.sessionStorage.setItem('garmin_pkce_verifier', 'test-verifier-abcdef')
+      win.localStorage.setItem(
+        'garmin_oauth_handshake',
+        JSON.stringify({
+          state: MOCK_STATE,
+          verifier: 'test-verifier-abcdef',
+          createdAt: Date.now()
+        })
+      )
     })
 
     // Simulate OAuth2 redirect callback with code + state

--- a/tests/unit/GarminOAuthHandshake.spec.ts
+++ b/tests/unit/GarminOAuthHandshake.spec.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import {
+  saveHandshake,
+  readHandshake,
+  clearHandshake,
+  markCodeConsumed,
+  isCodeConsumed
+} from '@plugins/data-providers/GarminProvider/client/oauthHandshake'
+
+describe('Garmin OAuth handshake', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('round-trips the state and the verifier', () => {
+    saveHandshake('state-abc', 'verifier-xyz')
+
+    const handshake = readHandshake()
+    expect(handshake?.state).toBe('state-abc')
+    expect(handshake?.verifier).toBe('verifier-xyz')
+  })
+
+  // The whole point of the move away from sessionStorage: in a PWA the callback
+  // can land in a browsing context that never saw the request being started.
+  it('survives in localStorage, not sessionStorage', () => {
+    saveHandshake('state-abc', 'verifier-xyz')
+
+    expect(sessionStorage.length).toBe(0)
+    expect(localStorage.length).toBeGreaterThan(0)
+  })
+
+  it('returns nothing once cleared', () => {
+    saveHandshake('state-abc', 'verifier-xyz')
+    clearHandshake()
+
+    expect(readHandshake()).toBeNull()
+  })
+
+  it('expires a handshake the user left behind', () => {
+    vi.useFakeTimers()
+    saveHandshake('state-abc', 'verifier-xyz')
+
+    vi.advanceTimersByTime(9 * 60 * 1000)
+    expect(readHandshake()).not.toBeNull()
+
+    vi.advanceTimersByTime(2 * 60 * 1000)
+    expect(readHandshake()).toBeNull()
+  })
+
+  it('survives a corrupted entry without throwing', () => {
+    localStorage.setItem('garmin_oauth_handshake', '{not json')
+    expect(readHandshake()).toBeNull()
+  })
+
+  describe('consumed codes', () => {
+    it('flags only the code that was consumed', () => {
+      markCodeConsumed('code-1')
+
+      expect(isCodeConsumed('code-1')).toBe(true)
+      expect(isCodeConsumed('code-2')).toBe(false)
+    })
+
+    it('reports nothing consumed on a fresh device', () => {
+      expect(isCodeConsumed('code-1')).toBe(false)
+    })
+
+    it('stops flagging a code once the duplicate window has passed', () => {
+      vi.useFakeTimers()
+      markCodeConsumed('code-1')
+
+      vi.advanceTimersByTime(30 * 1000)
+      expect(isCodeConsumed('code-1')).toBe(true)
+
+      vi.advanceTimersByTime(40 * 1000)
+      expect(isCodeConsumed('code-1')).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Symptôme

Sur la PWA, après la connexion Garmin : « Connected », puis immédiatement « OAuth error: state mismatch ».

## Cause

En standalone, la page d'autorisation n'est pas un popup : Android l'envoie dans une Custom Tab et COOP annule `window.opener`. `GarminOAuthCallback` bascule donc sur BroadcastChannel — mais il **broadcastait _et_ se redirigeait** vers `/data-provider/garmin?code=…&state=…`.

Le même `code` à usage unique partait deux fois :

1. la fenêtre PWA le reçoit, le `state` matche, l'échange réussit → **« Connected »** ;
2. la redirection le rejoue contre un handshake que la passe 1 vient d'effacer, depuis un contexte dont le `sessionStorage` est vide de toute façon → **« state mismatch »**.

Inoffensif jusqu'à 799acf1 : sous OAuth 1.0a la redirection transportait des tokens déjà obtenus et aucun `state` n'était vérifié, donc rejouer était idempotent. La migration PKCE a transformé ce double handoff en erreur.

## Correctif

- **Accusé de réception** : l'app répond `garmin-oauth-ack` ; la page de callback ne se redirige que si personne n'a répondu sous 2,5 s. Une seule livraison en vol.
- **Handshake en `localStorage`** (nouveau `oauthHandshake.ts`, TTL 10 min) : partagé par tous les contextes de même origine, ce que `sessionStorage` ne pouvait pas faire.
- **Idempotence** : un `code` déjà consommé est ignoré en silence, et la page se réaligne sur les tokens stockés — plus d'écran « déconnecté » alors que les tokens existent.

Deux bugs latents corrigés au passage, tous deux sur le chemin redirect :

- l'échange envoyait `window.location.href.split('?')[0]` comme `redirect_uri`, soit `/data-provider/garmin` — Garmin l'aurait rejeté, il doit être identique à celui de la requête d'autorisation ;
- la fermeture de la fenêtre était traitée comme une annulation et détruisait le handshake alors que l'utilisateur s'authentifiait encore dans la Custom Tab. Il expire désormais tout seul.

## Vérifications

- `npm run typecheck` (vue-tsc) : clean
- `npm run lint` : aucun nouveau warning
- `npm run build` : OK
- `npm run test:unit` : **811 passed**, dont 8 nouveaux sur le handshake (`tests/unit/GarminOAuthHandshake.spec.ts`)
- e2e Garmin mis à jour (il pré-remplissait `sessionStorage`) mais **non exécuté** : le binaire Cypress est bloqué par la policy réseau de l'environnement

---
_Generated by [Claude Code](https://claude.ai/code/session_01QE5tn5jyMsGbzqkcj9GGzc)_