### PR TITLE
feat(aggregates): suggestions prêtes à l'emploi, une card par agrégat, accès à la courbe

### DIFF
--- a/plugins/app-extensions/Statistics/aggregatePresets.ts
+++ b/plugins/app-extensions/Statistics/aggregatePresets.ts
@@ -1,0 +1,164 @@
+import type { CapabilityReport } from '@/composables/useSampleCapabilities'
+import type { CustomAggregateInput } from '@/services/CustomAggregateService'
+import type { SampleField } from '@/types/sampleFields'
+
+/**
+ * A ready-made aggregate, offered as one click instead of a form.
+ *
+ * The form asks eight questions before it produces anything, which is a lot to
+ * answer before knowing what the answers are worth. These are the aggregates
+ * worth having on a first visit: the reader picks one, sees a figure, and only
+ * then has a reason to build their own.
+ *
+ * Everything here is SI. A slope is a ratio, a speed is metres per second —
+ * the form converts at its boundary, and these never pass through it.
+ */
+export interface AggregatePreset {
+  id: string
+  labelKey: string
+  icon: string
+  /**
+   * Fields that must be *measured* for the suggestion to be offered.
+   *
+   * Not "declared" — measured. Suggesting a power aggregate to someone whose
+   * bike has no meter builds a filter that matches nothing and reads as a bug.
+   */
+  requires: SampleField[]
+  /** Built from the report, so a threshold can follow the reader's own data. */
+  build(report: CapabilityReport): Omit<CustomAggregateInput, 'label'>
+}
+
+/** Rounded to something a human would have typed, in SI. */
+function roundTo(value: number, step: number): number {
+  return Math.round(value / step) * step
+}
+
+function measured(report: CapabilityReport, field: SampleField) {
+  const capability = report.fields.find(f => f.field === field)
+  return capability?.availability === 'measured' ? capability : undefined
+}
+
+export const AGGREGATE_PRESETS: AggregatePreset[] = [
+  {
+    id: 'climb-heart-rate',
+    labelKey: 'customAggregates.presets.climbHeartRate',
+    icon: 'fas fa-heart-pulse',
+    requires: ['slope', 'heartRate'],
+    build: () => ({
+      enabled: true,
+      pinned: true,
+      // From 3%: below that a slope costs little enough that the effort reads
+      // as flat, and the band would swallow most of the outing.
+      where: [{ field: 'slope', min: 0.03 }],
+      measure: { field: 'heartRate', op: 'avg' },
+      weightBy: 'time',
+      periodOp: 'avg',
+      minWeight: 120
+    })
+  },
+  {
+    id: 'flat-speed',
+    labelKey: 'customAggregates.presets.flatSpeed',
+    icon: 'fas fa-arrows-left-right',
+    requires: ['slope', 'speed'],
+    build: () => ({
+      enabled: true,
+      pinned: true,
+      where: [{ field: 'slope', min: -0.01, max: 0.01 }],
+      measure: { field: 'speed', op: 'avg' },
+      weightBy: 'time',
+      periodOp: 'avg',
+      dimension: 'speed',
+      minWeight: 300
+    })
+  },
+  {
+    id: 'climb-speed',
+    labelKey: 'customAggregates.presets.climbSpeed',
+    icon: 'fas fa-mountain',
+    requires: ['slope', 'speed'],
+    build: () => ({
+      enabled: true,
+      where: [{ field: 'slope', min: 0.02, max: 0.1 }],
+      measure: { field: 'speed', op: 'avg' },
+      weightBy: 'time',
+      periodOp: 'avg',
+      dimension: 'speed',
+      minWeight: 120
+    })
+  },
+  {
+    id: 'descent-speed',
+    labelKey: 'customAggregates.presets.descentSpeed',
+    icon: 'fas fa-arrow-trend-down',
+    requires: ['slope', 'speed'],
+    build: () => ({
+      enabled: true,
+      where: [{ field: 'slope', max: -0.02 }],
+      measure: { field: 'speed', op: 'avg' },
+      weightBy: 'time',
+      periodOp: 'avg',
+      dimension: 'speed',
+      minWeight: 120
+    })
+  },
+  {
+    id: 'climb-power',
+    labelKey: 'customAggregates.presets.climbPower',
+    icon: 'fas fa-bolt',
+    requires: ['slope', 'power'],
+    build: () => ({
+      enabled: true,
+      where: [{ field: 'slope', min: 0.03 }],
+      measure: { field: 'power', op: 'avg' },
+      weightBy: 'time',
+      periodOp: 'avg',
+      minWeight: 120
+    })
+  },
+  {
+    id: 'hard-effort-speed',
+    labelKey: 'customAggregates.presets.hardEffortSpeed',
+    icon: 'fas fa-fire',
+    requires: ['heartRate', 'speed'],
+    /**
+     * The one threshold that cannot be a constant: "hard" is a different heart
+     * rate for every reader. Taken from their own distribution — the top decile
+     * of everything they have recorded — rather than from a formula on an age
+     * the app does not know.
+     */
+    build: report => {
+      const heartRate = measured(report, 'heartRate')
+      const threshold = heartRate?.p95 !== undefined ? roundTo(heartRate.p95, 5) : 160
+
+      return {
+        enabled: true,
+        where: [{ field: 'heartRate', min: threshold }],
+        measure: { field: 'speed', op: 'avg' },
+        weightBy: 'time',
+        periodOp: 'avg',
+        dimension: 'speed',
+        minWeight: 120
+      }
+    }
+  }
+]
+
+/**
+ * The suggestions worth showing: supported by the data, and not already taken.
+ *
+ * A suggestion the reader has already accepted stops being a suggestion —
+ * offering it again would create a duplicate that computes exactly the same
+ * thing under a second name.
+ */
+export function availablePresets(
+  report: CapabilityReport | null,
+  existingPresetIds: ReadonlySet<string>
+): AggregatePreset[] {
+  if (!report) return []
+
+  return AGGREGATE_PRESETS.filter(preset => {
+    if (existingPresetIds.has(preset.id)) return false
+    return preset.requires.every(field => measured(report, field) !== undefined)
+  })
+}

--- a/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
+++ b/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section v-if="!loading" class="custom-aggregates" data-test="custom-aggregates">
+  <section v-if="!loading" class="section-card custom-aggregates" data-test="custom-aggregates">
     <div class="section-header">
       <h3 class="section-title">
         <i class="fas fa-sliders" aria-hidden="true"></i>
@@ -27,8 +27,8 @@
           data-test="aggregate-new"
           @click="startCreate"
         >
-          <i class="fas fa-plus" aria-hidden="true"></i>
-          {{ t('customAggregates.add') }}
+          <i class="fas fa-sliders" aria-hidden="true"></i>
+          {{ t('customAggregates.addCustom') }}
         </button>
       </div>
     </div>
@@ -42,11 +42,39 @@
     </div>
 
     <ul v-if="pinned.length" class="tiles" data-test="aggregate-tiles">
-      <li v-for="tile in tiles" :key="tile.id" class="tile">
-        <span class="tile__label">{{ tile.label }}</span>
-        <span class="tile__value">{{ tile.value }}</span>
+      <li v-for="tile in tiles" :key="tile.id">
+        <button
+          type="button"
+          class="tile"
+          :aria-label="t('customAggregates.showCurve', { name: tile.label })"
+          @click="showCurveById(tile.id)"
+        >
+          <span class="tile__label">{{ tile.label }}</span>
+          <span class="tile__value">{{ tile.value }}</span>
+        </button>
       </li>
     </ul>
+
+    <!-- Suggestions come before the form, and are the intended way in. The form
+         asks eight questions before producing anything, which is a lot to
+         answer before knowing what the answers are worth. -->
+    <div v-if="!editing && suggestions.length" class="suggestions" data-test="aggregate-presets">
+      <p class="suggestions__lead">{{ t('customAggregates.suggestionsLead') }}</p>
+      <ul class="suggestions__list">
+        <li v-for="preset in suggestions" :key="preset.id">
+          <button
+            type="button"
+            class="suggestion"
+            :data-test="`preset-${preset.id}`"
+            @click="addPreset(preset)"
+          >
+            <i :class="preset.icon" aria-hidden="true"></i>
+            {{ t(preset.labelKey) }}
+            <i class="fas fa-plus suggestion__add" aria-hidden="true"></i>
+          </button>
+        </li>
+      </ul>
+    </div>
 
     <AggregateEditForm
       v-if="editing"
@@ -75,6 +103,15 @@
           <button
             type="button"
             class="btn-icon"
+            :aria-label="t('customAggregates.showCurve', { name: aggregate.label })"
+            :data-test="`aggregate-curve-${aggregate.id}`"
+            @click="showCurve(aggregate)"
+          >
+            <i class="fas fa-chart-line" aria-hidden="true"></i>
+          </button>
+          <button
+            type="button"
+            class="btn-icon"
             :aria-label="t('customAggregates.edit', { name: aggregate.label })"
             @click="startEdit(aggregate)"
           >
@@ -99,6 +136,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRouter } from 'vue-router'
 import { usePluginContext } from '@/composables/usePluginContext'
 import { useActivityMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import type { CapabilityReport } from '@/composables/useSampleCapabilities'
@@ -108,6 +146,7 @@ import type { CustomAggregate } from '@/types/customAggregate'
 import { SAMPLE_FIELD_SPECS } from '@/types/sampleFields'
 import { periodKey } from '@/utils/dateKeys'
 import { formatValue, toDisplay, unitOf } from '../aggregateFormat'
+import { availablePresets, type AggregatePreset } from '../aggregatePresets'
 import AggregateEditForm from './AggregateEditForm.vue'
 import type { Draft } from './AggregateEditForm.vue'
 
@@ -120,6 +159,7 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
+const router = useRouter()
 const ctx = usePluginContext()
 const { indexing, progress, ensureIndex } = useActivityMetricsIndex()
 
@@ -133,6 +173,14 @@ const edited = ref<CustomAggregate | null>(null)
 
 const sportScope = computed(() => props.selectedSport || undefined)
 const pinned = computed(() => aggregates.value.filter(a => a.pinned))
+
+/** Suggestions the data supports and the reader has not already taken. */
+const suggestions = computed(() =>
+  availablePresets(
+    report.value,
+    new Set(aggregates.value.map(a => a.presetId).filter((id): id is string => !!id))
+  )
+)
 
 const tiles = computed(() =>
   pinned.value.map(aggregate => ({
@@ -200,6 +248,48 @@ function describe(aggregate: CustomAggregate): string {
 
 function show(field: CustomAggregate['measure']['field'], si: number): string {
   return String(Math.round(toDisplay(ctx.units, field, si) * 10) / 10)
+}
+
+/**
+ * Accept a suggestion: one click, no form.
+ *
+ * The name is resolved from the locale here and stored as plain text, because
+ * from this point it is the reader's — they can rename it, and a key would
+ * overwrite that on the next locale change.
+ */
+async function addPreset(preset: AggregatePreset) {
+  if (!report.value) return
+
+  await ctx.aggregates.create({
+    ...preset.build(report.value),
+    label: t(preset.labelKey),
+    icon: preset.icon,
+    presetId: preset.id,
+    sports: sportScope.value ? [sportScope.value] : undefined
+  })
+
+  await runIndex()
+  await refresh()
+}
+
+/**
+ * Hand the aggregate to the metric tracker, which already owns the chart and
+ * its granularity and window controls.
+ *
+ * A link rather than a second chart here: duplicating the series engine in this
+ * plugin would mean two implementations of the same bucketing, and the two
+ * disagreeing about what a month holds is exactly the kind of drift the shared
+ * `derived.*` refs were meant to avoid.
+ */
+function showCurveById(id: string) {
+  void router.push({
+    path: '/metrics',
+    query: { metric: id, ...(props.selectedSport ? { sport: props.selectedSport } : {}) }
+  })
+}
+
+function showCurve(aggregate: CustomAggregate) {
+  showCurveById(aggregate.id)
 }
 
 function startCreate() {
@@ -286,8 +376,53 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.custom-aggregates {
-  margin-bottom: 1.5rem;
+/* The card shell itself comes from the global `.section-card`, like every
+   other section of this page. */
+
+.section-title i {
+  color: var(--color-green-500);
+}
+
+.suggestions {
+  margin-bottom: 1rem;
+}
+
+.suggestions__lead {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.suggestions__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.suggestion {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.85rem;
+  color: var(--text-color);
+  cursor: pointer;
+  background: var(--background-color);
+  border: 1px dashed var(--border-color);
+  border-radius: 999px;
+}
+
+.suggestion:hover {
+  border-style: solid;
+  border-color: var(--primary-color);
+}
+
+.suggestion__add {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
 }
 
 .section-header {
@@ -350,10 +485,17 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
+  width: 100%;
   padding: 0.7rem 0.8rem;
+  text-align: left;
+  cursor: pointer;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
+}
+
+.tile:hover {
+  border-color: var(--primary-color);
 }
 
 .tile__label {

--- a/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
+++ b/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
@@ -7,7 +7,7 @@
       </h3>
 
       <div class="header-actions">
-        <div v-if="pinned.length" class="period-chips" role="group">
+        <div v-if="aggregates.length" class="period-chips" role="group">
           <button
             v-for="p in PERIODS"
             :key="p"
@@ -41,20 +41,6 @@
       <p class="hint">{{ t('customAggregates.indexingHint') }}</p>
     </div>
 
-    <ul v-if="pinned.length" class="tiles" data-test="aggregate-tiles">
-      <li v-for="tile in tiles" :key="tile.id">
-        <button
-          type="button"
-          class="tile"
-          :aria-label="t('customAggregates.showCurve', { name: tile.label })"
-          @click="showCurveById(tile.id)"
-        >
-          <span class="tile__label">{{ tile.label }}</span>
-          <span class="tile__value">{{ tile.value }}</span>
-        </button>
-      </li>
-    </ul>
-
     <!-- Suggestions come before the form, and are the intended way in. The form
          asks eight questions before producing anything, which is a lot to
          answer before knowing what the answers are worth. -->
@@ -84,48 +70,55 @@
       @cancel="stopEditing"
     />
 
-    <ul v-if="aggregates.length" class="stack">
-      <li v-for="aggregate in aggregates" :key="aggregate.id" class="item">
-        <div class="item__text">
-          <span class="item__label">
+    <!-- One card per aggregate. The figure and the rule that produced it belong
+         together: they were two separate blocks, and a pinned aggregate then
+         appeared twice on the same page, once as a number and once as a rule,
+         with nothing saying they were the same thing. -->
+    <ul v-if="ordered.length" class="cards" data-test="aggregate-cards">
+      <li v-for="aggregate in ordered" :key="aggregate.id">
+        <article class="agg" :data-test="`aggregate-card-${aggregate.id}`">
+          <header class="agg__head">
+            <i :class="aggregate.icon || 'fas fa-chart-simple'" aria-hidden="true"></i>
+            <h4 class="agg__label">{{ aggregate.label }}</h4>
             <i
               v-if="aggregate.pinned"
-              class="fas fa-thumbtack"
+              class="fas fa-thumbtack agg__pin"
               :title="t('customAggregates.pinned')"
               aria-hidden="true"
             ></i>
-            {{ aggregate.label }}
-          </span>
-          <span class="item__desc">{{ describe(aggregate) }}</span>
-        </div>
+          </header>
 
-        <div class="item__actions">
-          <button
-            type="button"
-            class="btn-icon"
-            :aria-label="t('customAggregates.showCurve', { name: aggregate.label })"
-            :data-test="`aggregate-curve-${aggregate.id}`"
-            @click="showCurve(aggregate)"
-          >
-            <i class="fas fa-chart-line" aria-hidden="true"></i>
-          </button>
-          <button
-            type="button"
-            class="btn-icon"
-            :aria-label="t('customAggregates.edit', { name: aggregate.label })"
-            @click="startEdit(aggregate)"
-          >
-            <i class="fas fa-pen" aria-hidden="true"></i>
-          </button>
-          <button
-            type="button"
-            class="btn-icon"
-            :aria-label="t('customAggregates.delete', { name: aggregate.label })"
-            @click="onDelete(aggregate)"
-          >
-            <i class="fas fa-trash" aria-hidden="true"></i>
-          </button>
-        </div>
+          <p class="agg__value">{{ valueOf(aggregate) }}</p>
+          <p class="agg__desc">{{ describe(aggregate) }}</p>
+
+          <footer class="agg__actions">
+            <button
+              type="button"
+              class="btn-icon"
+              :aria-label="t('customAggregates.showCurve', { name: aggregate.label })"
+              :data-test="`aggregate-curve-${aggregate.id}`"
+              @click="showCurve(aggregate)"
+            >
+              <i class="fas fa-chart-line" aria-hidden="true"></i>
+            </button>
+            <button
+              type="button"
+              class="btn-icon"
+              :aria-label="t('customAggregates.edit', { name: aggregate.label })"
+              @click="startEdit(aggregate)"
+            >
+              <i class="fas fa-pen" aria-hidden="true"></i>
+            </button>
+            <button
+              type="button"
+              class="btn-icon"
+              :aria-label="t('customAggregates.delete', { name: aggregate.label })"
+              @click="onDelete(aggregate)"
+            >
+              <i class="fas fa-trash" aria-hidden="true"></i>
+            </button>
+          </footer>
+        </article>
       </li>
     </ul>
 
@@ -172,7 +165,21 @@ const editing = ref(false)
 const edited = ref<CustomAggregate | null>(null)
 
 const sportScope = computed(() => props.selectedSport || undefined)
-const pinned = computed(() => aggregates.value.filter(a => a.pinned))
+
+/**
+ * Pinned first, then by name.
+ *
+ * Pinning no longer decides whether an aggregate is shown — every one has its
+ * card now — so what is left of it is where it sits. That is still worth
+ * having: the two or three a reader actually watches should not drift down the
+ * grid as they define more.
+ */
+const ordered = computed(() =>
+  [...aggregates.value].sort((a, b) => {
+    if (!!a.pinned !== !!b.pinned) return a.pinned ? -1 : 1
+    return a.label.localeCompare(b.label)
+  })
+)
 
 /** Suggestions the data supports and the reader has not already taken. */
 const suggestions = computed(() =>
@@ -182,16 +189,18 @@ const suggestions = computed(() =>
   )
 )
 
-const tiles = computed(() =>
-  pinned.value.map(aggregate => ({
-    id: aggregate.id,
-    label: aggregate.label,
-    value:
-      values.value[aggregate.id] === undefined
-        ? t('customAggregates.noValue')
-        : formatValue(ctx.units, aggregate.measure.field, values.value[aggregate.id])
-  }))
-)
+/**
+ * The figure of the period being read, or a plain statement that there is none.
+ *
+ * A card showing nothing where a number belongs reads as a bug; one saying so
+ * reads as an aggregate that has not matched anything yet, which is what it is.
+ */
+function valueOf(aggregate: CustomAggregate): string {
+  const value = values.value[aggregate.id]
+  return value === undefined
+    ? t('customAggregates.noValue')
+    : formatValue(ctx.units, aggregate.measure.field, value)
+}
 
 async function refresh() {
   aggregates.value = await ctx.aggregates.list()
@@ -212,7 +221,7 @@ async function loadValues() {
   const next: Record<string, number> = {}
 
   await Promise.all(
-    pinned.value.map(async aggregate => {
+    aggregates.value.map(async aggregate => {
       const records = await ctx.aggregation.getAggregated(aggregate.id, period.value)
       const record = records.find(r => r.periodKey === currentKey)
       if (record) next[aggregate.id] = record.value
@@ -281,15 +290,14 @@ async function addPreset(preset: AggregatePreset) {
  * disagreeing about what a month holds is exactly the kind of drift the shared
  * `derived.*` refs were meant to avoid.
  */
-function showCurveById(id: string) {
+function showCurve(aggregate: CustomAggregate) {
   void router.push({
     path: '/metrics',
-    query: { metric: id, ...(props.selectedSport ? { sport: props.selectedSport } : {}) }
+    query: {
+      metric: aggregate.id,
+      ...(props.selectedSport ? { sport: props.selectedSport } : {})
+    }
   })
-}
-
-function showCurve(aggregate: CustomAggregate) {
-  showCurveById(aggregate.id)
 }
 
 function startCreate() {
@@ -472,41 +480,66 @@ onUnmounted(() => {
   border-color: var(--primary-color);
 }
 
-.tiles {
+.cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
   gap: 0.6rem;
   padding: 0;
-  margin: 0 0 1rem;
+  margin: 0.75rem 0 0;
   list-style: none;
 }
 
-.tile {
+.agg {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  width: 100%;
-  padding: 0.7rem 0.8rem;
-  text-align: left;
-  cursor: pointer;
+  height: 100%;
+  padding: 0.8rem 0.9rem;
   background: var(--card-background);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
 }
 
-.tile:hover {
-  border-color: var(--primary-color);
+.agg__head {
+  display: flex;
+  gap: 0.45rem;
+  align-items: baseline;
 }
 
-.tile__label {
+.agg__head i {
+  color: var(--color-green-500);
+}
+
+.agg__label {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.agg__pin {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.agg__value {
+  margin: 0.4rem 0 0.15rem;
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.agg__desc {
+  flex: 1;
+  margin: 0 0 0.6rem;
   font-size: 0.78rem;
   color: var(--text-secondary);
 }
 
-.tile__value {
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: var(--text-color);
+.agg__actions {
+  display: flex;
+  gap: 0.3rem;
 }
 
 .indexing {
@@ -536,50 +569,11 @@ onUnmounted(() => {
   transition: width 0.2s ease;
 }
 
-.stack {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0;
-  margin: 0.75rem 0 0;
-  list-style: none;
-}
 
-.item {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.7rem 0.9rem;
-  background: var(--card-background);
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
-}
 
-.item__text {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 0.15rem;
-  min-width: 0;
-}
 
-.item__label {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: 600;
-  color: var(--text-color);
-}
 
-.item__desc {
-  font-size: 0.82rem;
-  color: var(--text-secondary);
-}
 
-.item__actions {
-  display: flex;
-  gap: 0.35rem;
-}
 
 .empty {
   margin: 0;

--- a/plugins/app-extensions/Statistics/components/StatisticsView.vue
+++ b/plugins/app-extensions/Statistics/components/StatisticsView.vue
@@ -23,6 +23,18 @@
       <!-- First: what the reader chose to follow. The built-in sections answer
            the questions everyone has, this one answers theirs. -->
       <CustomAggregatesSection :selected-sport="selectedSport" :activities="filteredActivities" />
+
+      <!-- Plugins that answer the same question as this page render here. Right
+           under the aggregates rather than at the bottom: the metric tracker is
+           where one becomes a curve, and a chart five sections below the figure
+           it explains is a chart nobody connects to it. -->
+      <component
+        :is="section"
+        v-for="(section, i) in sectionComponents"
+        :key="`section-${i}`"
+        :sport="selectedSport"
+      />
+
       <SummarySection :selected-sport="selectedSport" />
       <CalendarHeatmap :activities="filteredActivities" />
       <TrendsSection :activities="filteredActivities" />
@@ -32,14 +44,6 @@
         :selected-sport="selectedSport"
       />
       <PersonalRecordsSection :activities="filteredActivities" :selected-sport="selectedSport" />
-
-      <!-- Plugins that answer the same question as this page render here -->
-      <component
-        :is="section"
-        v-for="(section, i) in sectionComponents"
-        :key="`section-${i}`"
-        :sport="selectedSport"
-      />
     </div>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -929,7 +929,7 @@
   "customAggregates": {
     "title": "My aggregates",
     "add": "New aggregate",
-    "empty": "No aggregate yet. Create one to follow a figure the built-in metrics do not cover.",
+    "empty": "Nothing followed yet. Pick a suggestion above, or build your own.",
     "pinned": "Pinned to the top of the dashboard",
     "edit": "Edit {name}",
     "delete": "Delete {name}",
@@ -976,6 +976,17 @@
       "week": "Week",
       "month": "Month",
       "year": "Year"
+    },
+    "addCustom": "Build my own",
+    "showCurve": "Show the curve for {name}",
+    "suggestionsLead": "Ready-made, from what your activities recorded — one click to follow one:",
+    "presets": {
+      "climbHeartRate": "Heart rate on climbs",
+      "flatSpeed": "Speed on the flat",
+      "climbSpeed": "Speed on climbs",
+      "descentSpeed": "Speed on descents",
+      "climbPower": "Power on climbs",
+      "hardEffortSpeed": "Speed at high heart rate"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -929,7 +929,7 @@
   "customAggregates": {
     "title": "Mes agrégats",
     "add": "Nouvel agrégat",
-    "empty": "Aucun agrégat pour l'instant. Créez-en un pour suivre un chiffre que les métriques natives ne couvrent pas.",
+    "empty": "Rien de suivi pour le moment. Choisissez une suggestion ci-dessus, ou créez le vôtre.",
     "pinned": "Épinglé en tête du tableau de bord",
     "edit": "Modifier {name}",
     "delete": "Supprimer {name}",
@@ -976,6 +976,17 @@
       "week": "Semaine",
       "month": "Mois",
       "year": "Année"
+    },
+    "addCustom": "Créer le mien",
+    "showCurve": "Voir la courbe de {name}",
+    "suggestionsLead": "Prêts à l'emploi, d'après ce que vos activités ont enregistré — un clic pour en suivre un :",
+    "presets": {
+      "climbHeartRate": "Fréquence cardiaque en côte",
+      "flatSpeed": "Vitesse sur le plat",
+      "climbSpeed": "Vitesse en côte",
+      "descentSpeed": "Vitesse en descente",
+      "climbPower": "Puissance en côte",
+      "hardEffortSpeed": "Vitesse à haute fréquence cardiaque"
     }
   }
 }

--- a/src/types/customAggregate.ts
+++ b/src/types/customAggregate.ts
@@ -69,6 +69,16 @@ export interface CustomAggregate extends Timestamped {
   /** User-authored, free text. NOT an i18n key — see the note below. */
   label: string
   icon?: string
+  /**
+   * The suggestion this was created from, when it was not built by hand.
+   *
+   * Kept so the same suggestion is not offered twice, and it survives a rename
+   * — which matching on the label would not. Deliberately absent from
+   * `definitionHash`: where an aggregate came from says nothing about what it
+   * computes, and editing a suggested one until it means something else must
+   * not recompute anything a hand-built twin would not.
+   */
+  presetId?: string
   /** Lowercased sport types; empty or absent means every sport. */
   sports?: string[]
   enabled: boolean

--- a/tests/unit/CustomAggregatesSection.spec.ts
+++ b/tests/unit/CustomAggregatesSection.spec.ts
@@ -132,22 +132,45 @@ describe('CustomAggregatesSection', () => {
     expect(wrapper.find('[data-test="aggregate-new"]').exists()).toBe(true)
   })
 
-  it('shows a tile for a pinned aggregate, with the figure of the current period', async () => {
-    const wrapper = render(context({ aggregates: [aggregate({ pinned: true })] }))
-    await flushPromises()
-
-    const tiles = wrapper.find('[data-test="aggregate-tiles"]')
-    expect(tiles.exists()).toBe(true)
-    expect(tiles.text()).toContain('Climb heart rate')
-    expect(tiles.text()).toContain('152')
-  })
-
-  it('leaves an unpinned aggregate out of the tiles but keeps it in the list', async () => {
+  /**
+   * One card per aggregate, figure included. The figure and the rule behind it
+   * used to live in two separate blocks, so a pinned aggregate appeared twice
+   * on the same page with nothing saying it was the same thing.
+   */
+  it('gives every aggregate one card carrying its figure of the current period', async () => {
     const wrapper = render(context({ aggregates: [aggregate({ pinned: false })] }))
     await flushPromises()
 
-    expect(wrapper.find('[data-test="aggregate-tiles"]').exists()).toBe(false)
-    expect(wrapper.find('.stack').text()).toContain('Climb heart rate')
+    const cards = wrapper.findAll('[data-test="aggregate-cards"] .agg')
+    expect(cards).toHaveLength(1)
+    expect(cards[0].text()).toContain('Climb heart rate')
+    expect(cards[0].find('.agg__value').text()).toContain('152')
+  })
+
+  it('says so plainly on a card with no figure yet', async () => {
+    const ctx = context({ aggregates: [aggregate()] })
+    ;(ctx.aggregation.getAggregated as unknown as { mockResolvedValue: (v: unknown) => void })
+      .mockResolvedValue([])
+
+    const wrapper = render(ctx)
+    await flushPromises()
+
+    expect(wrapper.find('.agg__value').text()).toContain('No data')
+  })
+
+  it('puts the pinned ones first, since pinning now decides rank rather than presence', async () => {
+    const wrapper = render(
+      context({
+        aggregates: [
+          aggregate({ id: 'plain', label: 'AAA plain', pinned: false }),
+          aggregate({ id: 'pin', label: 'ZZZ pinned', pinned: true })
+        ]
+      })
+    )
+    await flushPromises()
+
+    const labels = wrapper.findAll('.agg__label').map(el => el.text())
+    expect(labels).toEqual(['ZZZ pinned', 'AAA plain'])
   })
 
   /** Reading the rule back, in the reader's units — a slope stored as a ratio. */
@@ -155,7 +178,7 @@ describe('CustomAggregatesSection', () => {
     const wrapper = render(context({ aggregates: [aggregate()] }))
     await flushPromises()
 
-    const description = wrapper.find('.item__desc').text()
+    const description = wrapper.find('.agg__desc').text()
     expect(description).toContain('Average')
     expect(description).toContain('Heart rate')
     expect(description).toContain('2–10 %')
@@ -203,7 +226,7 @@ describe('CustomAggregatesSection', () => {
     const wrapper = render(ctx)
     await flushPromises()
 
-    await wrapper.find('.item__actions .btn-icon:last-child').trigger('click')
+    await wrapper.find('.agg__actions .btn-icon:last-child').trigger('click')
     await flushPromises()
 
     expect(ctx.aggregates.remove).toHaveBeenCalledWith('agg-1')

--- a/tests/unit/CustomAggregatesSection.spec.ts
+++ b/tests/unit/CustomAggregatesSection.spec.ts
@@ -8,6 +8,7 @@ import type { CapabilityReport } from '@/composables/useSampleCapabilities'
 import type { CustomAggregate } from '@/types/customAggregate'
 import type { PluginContext } from '@/types/plugin-context'
 import { periodKey } from '@/utils/dateKeys'
+import type { SampleField } from '@/types/sampleFields'
 import { createActivity } from '../fixtures/activities'
 import en from '@/locales/en.json'
 
@@ -15,9 +16,13 @@ const ensureIndex = vi.fn(async () => undefined)
 const indexing = ref(false)
 const progress = ref(0)
 
+const push = vi.fn()
+
 vi.mock('@/composables/useActivityMetricsIndex', () => ({
   useActivityMetricsIndex: () => ({ indexing, progress, ensureIndex })
 }))
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
 
 const CustomAggregatesSection = (
   await import('@plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue')
@@ -40,20 +45,27 @@ function aggregate(over: Partial<CustomAggregate> = {}): CustomAggregate {
   }
 }
 
-function measuredReport(measured = true): CapabilityReport {
+function field(name: SampleField, measured: boolean) {
+  return {
+    field: name,
+    labelKey: `sampleFields.${name}`,
+    availability: (measured ? 'measured' : 'absent') as 'measured' | 'absent',
+    activityCount: measured ? 5 : 0,
+    activityRatio: measured ? 1 : 0,
+    sampleCount: measured ? 900 : 0,
+    ...(measured ? { min: 90, max: 180, mean: 140, p05: 100, p50: 140, p95: 173 } : {})
+  }
+}
+
+function measuredReport(measured = true, extra: SampleField[] = []): CapabilityReport {
   return {
     activityCount: 5,
     sports: ['running'],
     fields: [
-      {
-        field: 'heartRate',
-        labelKey: 'sampleFields.heartRate',
-        availability: measured ? 'measured' : 'absent',
-        activityCount: measured ? 5 : 0,
-        activityRatio: measured ? 1 : 0,
-        sampleCount: measured ? 900 : 0,
-        ...(measured ? { min: 90, max: 180, mean: 140, p05: 100, p50: 140, p95: 175 } : {})
-      }
+      field('heartRate', measured),
+      ...(['slope', 'speed', 'power'] as SampleField[]).map(f =>
+        field(f, measured && extra.includes(f))
+      )
     ]
   }
 }
@@ -106,6 +118,7 @@ describe('CustomAggregatesSection', () => {
   beforeEach(() => {
     setUnitSystem('metric')
     ensureIndex.mockClear()
+    push.mockClear()
     indexing.value = false
     progress.value = 0
   })
@@ -115,7 +128,7 @@ describe('CustomAggregatesSection', () => {
     await flushPromises()
 
     expect(wrapper.find('[data-test="custom-aggregates"]').exists()).toBe(true)
-    expect(wrapper.text()).toContain('No aggregate yet')
+    expect(wrapper.text()).toContain('Nothing followed yet')
     expect(wrapper.find('[data-test="aggregate-new"]').exists()).toBe(true)
   })
 
@@ -195,5 +208,100 @@ describe('CustomAggregatesSection', () => {
 
     expect(ctx.aggregates.remove).toHaveBeenCalledWith('agg-1')
     expect(ensureIndex).toHaveBeenCalled()
+  })
+})
+
+describe('CustomAggregatesSection — suggestions', () => {
+  beforeEach(() => {
+    setUnitSystem('metric')
+    ensureIndex.mockClear()
+    push.mockClear()
+    indexing.value = false
+  })
+
+  /**
+   * The point of the suggestions: the form asks eight questions before it
+   * produces anything, which is a lot to answer before knowing what the answers
+   * are worth.
+   */
+  it('offers ready-made aggregates the data supports', async () => {
+    const wrapper = render(context({ report: measuredReport(true, ['slope', 'speed']) }))
+    await flushPromises()
+
+    const presets = wrapper.find('[data-test="aggregate-presets"]')
+    expect(presets.exists()).toBe(true)
+    expect(presets.text()).toContain('Heart rate on climbs')
+    expect(presets.text()).toContain('Speed on the flat')
+  })
+
+  /** Suggesting a power aggregate to a bike with no meter builds a dead filter. */
+  it('withholds a suggestion whose field nothing recorded', async () => {
+    const wrapper = render(context({ report: measuredReport(true, ['slope', 'speed']) }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="preset-climb-power"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="preset-climb-speed"]').exists()).toBe(true)
+  })
+
+  it('shows nothing at all when the data supports no suggestion', async () => {
+    const wrapper = render(context({ report: measuredReport(true) }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="aggregate-presets"]').exists()).toBe(false)
+  })
+
+  it('creates from a suggestion in one click, naming it from the locale', async () => {
+    const ctx = context({ report: measuredReport(true, ['slope', 'speed']) })
+    const wrapper = render(ctx)
+    await flushPromises()
+
+    await wrapper.find('[data-test="preset-climb-heart-rate"]').trigger('click')
+    await flushPromises()
+
+    expect(ctx.aggregates.create).toHaveBeenCalledTimes(1)
+    const [draft] = (ctx.aggregates.create as unknown as { mock: { calls: [CustomAggregate][] } })
+      .mock.calls[0]
+
+    expect(draft.label).toBe('Heart rate on climbs')
+    expect(draft.presetId).toBe('climb-heart-rate')
+    expect(draft.measure).toEqual({ field: 'heartRate', op: 'avg' })
+    // A slope is stored as the ratio it is, never as a percentage.
+    expect(draft.where[0]).toEqual({ field: 'slope', min: 0.03 })
+    expect(ensureIndex).toHaveBeenCalled()
+  })
+
+  /** Offering it twice would create a duplicate computing exactly the same thing. */
+  it('stops offering a suggestion already taken', async () => {
+    const wrapper = render(
+      context({
+        report: measuredReport(true, ['slope', 'speed']),
+        aggregates: [aggregate({ presetId: 'climb-heart-rate' })]
+      })
+    )
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="preset-climb-heart-rate"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="preset-flat-speed"]').exists()).toBe(true)
+  })
+
+  it('hands an aggregate to the tracker, which owns the chart and its windows', async () => {
+    const wrapper = render(context({ aggregates: [aggregate()] }))
+    await flushPromises()
+
+    await wrapper.find('[data-test="aggregate-curve-agg-1"]').trigger('click')
+
+    expect(push).toHaveBeenCalledWith({ path: '/metrics', query: { metric: 'agg-1' } })
+  })
+
+  it('carries the sport filter into the curve', async () => {
+    const wrapper = render(context({ aggregates: [aggregate()] }), { selectedSport: 'running' })
+    await flushPromises()
+
+    await wrapper.find('[data-test="aggregate-curve-agg-1"]').trigger('click')
+
+    expect(push).toHaveBeenCalledWith({
+      path: '/metrics',
+      query: { metric: 'agg-1', sport: 'running' }
+    })
   })
 })


### PR DESCRIPTION
Suite de #93, à l'usage. Quatre corrections d'ergonomie sur la section « Mes agrégats » du tableau de bord.

## La coquille

La section était **la seule de la page à ne pas porter `.section-card`**, la classe globale que ses cinq voisines utilisent. Elle flottait sans cadre.

## Le formulaire recule, les suggestions passent devant

Arriver directement sur le formulaire était le vrai problème : il pose huit questions avant de produire quoi que ce soit, ce qui fait beaucoup à répondre avant de savoir ce que valent les réponses.

Six agrégats prêts à l'emploi sont proposés à la place — FC en côte, vitesse sur le plat, vitesse en côte, vitesse en descente, puissance en côte, vitesse à haute FC — chacun en un clic. Le formulaire passe derrière un bouton explicite « Créer le mien ».

Une suggestion n'apparaît **que si les données la supportent** : le filtrage porte sur `measured`, pas sur « déclaré ». Proposer un agrégat de puissance à un vélo sans capteur construit un filtre qui ne matche rien et se lit comme un bug.

Un seuil ne pouvait pas être une constante — « effort dur » est une fréquence cardiaque différente pour chaque personne. Il est pris sur le p95 du lecteur lui-même, arrondi à 5 bpm, plutôt que sur une formule appliquée à un âge que l'app ne connaît pas.

`presetId` retient de quelle suggestion vient un agrégat, pour ne pas la reproposer. Il survit à un renommage — ce qu'un matching sur le libellé ne ferait pas — et reste hors de `definitionHash` : d'où vient un agrégat ne dit rien de ce qu'il calcule.

## Une card par agrégat

Le chiffre et la règle qui le produit vivaient dans deux blocs séparés : une rangée de tuiles pour les épinglés, une liste de règles en dessous. Un agrégat épinglé apparaissait donc **deux fois sur la même page**, une fois comme nombre et une fois comme description, sans que rien ne dise que c'était la même chose.

Ils sont maintenant une seule card : nom, chiffre de la période, la règle relue dans les unités du lecteur, et ses actions.

L'épinglage cesse de décider si un agrégat est affiché — ils le sont tous — et décide de son rang. Ça reste utile : les deux ou trois qu'on regarde vraiment ne doivent pas descendre dans la grille à mesure qu'on en définit d'autres.

Une card sans chiffre l'écrit au lieu de laisser le vide : un espace blanc là où un nombre est attendu se lit comme un bug, « pas de donnée » se lit comme un agrégat qui n'a encore rien matché.

## L'accès à la courbe

Il n'y en avait aucun. Chaque agrégat se passe désormais au Metric Tracker, qui possède déjà le graphe avec ses fenêtres de période et de temps. Un lien plutôt qu'un second graphe ici : dupliquer le moteur de séries dans ce plugin, c'est deux implémentations du même découpage en périodes, et le jour où elles divergent sur ce que contient un mois, rien ne dira laquelle croire.

La section du tracker remonte aussi juste sous les agrégats. Un graphe cinq sections plus bas que le chiffre qu'il explique est un graphe que personne ne relie au chiffre.

## Vérifications

- `npm run typecheck` (vue-tsc) : clean
- `npm run test:unit` : **974 passés**
- `npm run lint` : 0 erreur (6 warnings préexistants)

## Ce qui n'a pas été vérifié

Le rendu visuel, comme pour #93 : l'environnement de développement n'a ni navigateur utilisable ni binaire Cypress installable. À regarder au premier lancement, en particulier le passage à la ligne des six chips de suggestion en mobile, et si leur bordure pointillée se lit bien comme « à activer » plutôt que comme un champ désactivé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaTtfq1vFkgSWSgeabzwjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaTtfq1vFkgSWSgeabzwjv)_