### PR TITLE
feat(aggregates): une courbe par card épinglée, gestion derrière une roue dentée

### DIFF
--- a/plugins/app-extensions/Statistics/aggregateSeries.ts
+++ b/plugins/app-extensions/Statistics/aggregateSeries.ts
@@ -1,0 +1,55 @@
+import type { AggregatedRecord, AggregationPeriod } from '@/types/aggregation'
+
+/** Time windows a card can be narrowed to. */
+export type WindowId = 'all' | '12m' | '6m' | '3m'
+
+/**
+ * How many buckets a window holds, per period.
+ *
+ * Expressed in buckets rather than in dates because that is what the records
+ * are: `buildAggregateRecords` already did the bucketing, so a window here is a
+ * count of the tail, not a second date computation that could disagree with the
+ * first about where a week starts.
+ *
+ * A year period has no window: three months of yearly buckets is one point, and
+ * a chart of one point is a chart nobody can read.
+ */
+const WINDOW_BUCKETS: Record<AggregationPeriod, Partial<Record<WindowId, number>>> = {
+  week: { '3m': 13, '6m': 26, '12m': 52 },
+  month: { '3m': 3, '6m': 6, '12m': 12 },
+  year: {}
+}
+
+/** Windows worth offering — the ones that would leave more than one point. */
+export function availableWindows(period: AggregationPeriod): WindowId[] {
+  const offered = Object.keys(WINDOW_BUCKETS[period]) as WindowId[]
+  return offered.length ? [...offered.sort(), 'all'] : []
+}
+
+export interface SeriesPoint {
+  key: string
+  value: number
+}
+
+/**
+ * The points to plot, oldest first.
+ *
+ * Sorted on the period key, which is safe because every key of a given period
+ * has the same shape and the same width — `2026-W05` before `2026-W30`,
+ * `2026-07` before `2026-11`. A window keeps the tail, so a chart always ends
+ * on the period being read rather than on whichever one happened to be last in
+ * the store.
+ */
+export function buildSeries(
+  records: AggregatedRecord[],
+  period: AggregationPeriod,
+  window: WindowId
+): SeriesPoint[] {
+  const points = records
+    .filter(r => r.periodType === period && Number.isFinite(r.value))
+    .sort((a, b) => a.periodKey.localeCompare(b.periodKey))
+    .map(r => ({ key: r.periodKey, value: r.value }))
+
+  const size = WINDOW_BUCKETS[period][window]
+  return size === undefined ? points : points.slice(-size)
+}

--- a/plugins/app-extensions/Statistics/components/AggregateCard.vue
+++ b/plugins/app-extensions/Statistics/components/AggregateCard.vue
@@ -1,0 +1,284 @@
+<template>
+  <article class="agg" :data-test="`aggregate-card-${aggregate.id}`">
+    <header class="agg__head">
+      <i :class="aggregate.icon || 'fas fa-chart-simple'" aria-hidden="true"></i>
+      <h4 class="agg__label">{{ aggregate.label }}</h4>
+      <span class="agg__value">{{ currentValue }}</span>
+    </header>
+
+    <p class="agg__desc">{{ describe(aggregate) }}</p>
+
+    <div v-if="points.length > 1" class="agg__chart">
+      <canvas ref="canvas" :aria-label="t('customAggregates.chartOf', { name: aggregate.label })">
+      </canvas>
+    </div>
+    <p v-else class="agg__thin">{{ t('customAggregates.notEnoughPoints') }}</p>
+
+    <footer class="agg__controls">
+      <div class="chips" role="group" :aria-label="t('customAggregates.period')">
+        <button
+          v-for="p in PERIODS"
+          :key="p"
+          type="button"
+          class="chip"
+          :class="{ 'chip--on': period === p }"
+          :aria-pressed="period === p"
+          :data-test="`period-${p}`"
+          @click="period = p"
+        >
+          {{ t(`customAggregates.periods.${p}`) }}
+        </button>
+      </div>
+
+      <!-- Absent on a yearly card: three months of yearly buckets is one point. -->
+      <div
+        v-if="windows.length"
+        class="chips"
+        role="group"
+        :aria-label="t('customAggregates.window')"
+      >
+        <button
+          v-for="w in windows"
+          :key="w"
+          type="button"
+          class="chip"
+          :class="{ 'chip--on': window === w }"
+          :aria-pressed="window === w"
+          :data-test="`window-${w}`"
+          @click="window = w"
+        >
+          {{ t(`customAggregates.windows.${w}`) }}
+        </button>
+      </div>
+    </footer>
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Chart from 'chart.js/auto'
+import { usePluginContext } from '@/composables/usePluginContext'
+import type { AggregatedRecord, AggregationPeriod } from '@/types/aggregation'
+import type { CustomAggregate } from '@/types/customAggregate'
+import { SAMPLE_FIELD_SPECS } from '@/types/sampleFields'
+import { periodKey } from '@/utils/dateKeys'
+import { formatValue, toDisplay, unitOf } from '../aggregateFormat'
+import { availableWindows, buildSeries, type WindowId } from '../aggregateSeries'
+
+const PERIODS: AggregationPeriod[] = ['week', 'month', 'year']
+
+const props = defineProps<{ aggregate: CustomAggregate }>()
+
+const { t } = useI18n()
+const ctx = usePluginContext()
+
+const records = ref<AggregatedRecord[]>([])
+const period = ref<AggregationPeriod>('month')
+const window = ref<WindowId>('12m')
+const canvas = ref<HTMLCanvasElement | null>(null)
+let chart: Chart | null = null
+
+const windows = computed(() => availableWindows(period.value))
+const points = computed(() => buildSeries(records.value, period.value, window.value))
+
+/** The figure of the period being read, not the last one on record. */
+const currentValue = computed(() => {
+  const key = periodKey(new Date(), period.value)
+  const record = records.value.find(r => r.periodType === period.value && r.periodKey === key)
+  return record
+    ? formatValue(ctx.units, props.aggregate.measure.field, record.value)
+    : t('customAggregates.noValue')
+})
+
+/**
+ * The rule, read back in the reader's units.
+ *
+ * Built from the definition rather than stored beside it: a description that is
+ * a second copy of the rule drifts from it the first time the rule is edited.
+ */
+function describe(aggregate: CustomAggregate): string {
+  const measure = t(SAMPLE_FIELD_SPECS[aggregate.measure.field].labelKey)
+  const op = t(`customAggregates.ops.${aggregate.measure.op}`)
+
+  const bands = aggregate.where.map(filter => {
+    const name = t(SAMPLE_FIELD_SPECS[filter.field].labelKey)
+    const unit = unitOf(ctx.units, filter.field)
+    const low = filter.min !== undefined ? show(filter.field, filter.min) : null
+    const high = filter.max !== undefined ? show(filter.field, filter.max) : null
+
+    if (low !== null && high !== null) return `${name} ${low}–${high} ${unit}`
+    if (low !== null) return `${name} ≥ ${low} ${unit}`
+    return `${name} < ${high} ${unit}`
+  })
+
+  return bands.length ? `${op} ${measure} — ${bands.join(', ')}` : `${op} ${measure}`
+}
+
+function show(field: CustomAggregate['measure']['field'], si: number): string {
+  return String(Math.round(toDisplay(ctx.units, field, si) * 10) / 10)
+}
+
+async function load() {
+  records.value = await ctx.aggregation.getAggregated(props.aggregate.id, period.value)
+}
+
+function draw() {
+  const spec = SAMPLE_FIELD_SPECS[props.aggregate.measure.field]
+  const labels = points.value.map(p => p.key)
+  // Plotted in the reader's units, like every figure on the card. A chart in
+  // metres per second beside a value in km/h would read as two measurements.
+  const data = points.value.map(
+    p => Math.round(toDisplay(ctx.units, props.aggregate.measure.field, p.value) * 10) / 10
+  )
+
+  if (chart) {
+    chart.data.labels = labels
+    chart.data.datasets[0].data = data
+    chart.update()
+    return
+  }
+
+  if (!canvas.value) return
+
+  const style = getComputedStyle(document.documentElement)
+  const green500 = style.getPropertyValue('--color-green-500').trim() || '#88aa00'
+
+  chart = new Chart(canvas.value, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: props.aggregate.label,
+          data,
+          borderColor: green500,
+          backgroundColor: `${green500}1a`,
+          fill: true,
+          tension: 0.3,
+          pointRadius: 2
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: {
+        x: { grid: { display: false } },
+        // Not from zero: these are averages within a band, and a heart rate
+        // axis starting at zero flattens every variation worth seeing.
+        y: { beginAtZero: false, title: { display: false, text: spec.unit ?? '' } }
+      }
+    }
+  })
+}
+
+/** A window that means nothing for the new period would leave an empty chart. */
+watch(period, async () => {
+  if (windows.value.length && !windows.value.includes(window.value)) window.value = 'all'
+  await load()
+})
+
+watch([points, canvas], async () => {
+  await nextTick()
+  draw()
+})
+
+onMounted(async () => {
+  await load()
+  await nextTick()
+  draw()
+})
+
+onBeforeUnmount(() => {
+  chart?.destroy()
+  chart = null
+})
+</script>
+
+<style scoped>
+.agg {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0.9rem 1rem;
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+}
+
+.agg__head {
+  display: flex;
+  gap: 0.45rem;
+  align-items: baseline;
+}
+
+.agg__head i {
+  color: var(--color-green-500);
+}
+
+.agg__label {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.agg__value {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-color);
+  white-space: nowrap;
+}
+
+.agg__desc {
+  margin: 0.2rem 0 0.7rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.agg__chart {
+  position: relative;
+  height: 150px;
+}
+
+.agg__thin {
+  padding: 1.5rem 0;
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.agg__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
+  margin-top: 0.7rem;
+}
+
+.chips {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.chip {
+  padding: 0.3rem 0.55rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  background: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+}
+
+.chip--on {
+  color: var(--text-on-primary, #fff);
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/AggregateManager.vue
+++ b/plugins/app-extensions/Statistics/components/AggregateManager.vue
@@ -1,0 +1,295 @@
+<template>
+  <div class="manager" data-test="aggregate-manager">
+    <!-- Suggestions first, and the form last: the form asks eight questions
+         before producing anything, which is a lot to answer before knowing what
+         the answers are worth. -->
+    <div v-if="!editing && suggestions.length" class="suggestions" data-test="aggregate-presets">
+      <p class="lead">{{ t('customAggregates.suggestionsLead') }}</p>
+      <ul class="suggestions__list">
+        <li v-for="preset in suggestions" :key="preset.id">
+          <button
+            type="button"
+            class="suggestion"
+            :data-test="`preset-${preset.id}`"
+            @click="$emit('add-preset', preset)"
+          >
+            <i :class="preset.icon" aria-hidden="true"></i>
+            {{ t(preset.labelKey) }}
+            <i class="fas fa-plus suggestion__add" aria-hidden="true"></i>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <ul v-if="aggregates.length" class="rows">
+      <li v-for="aggregate in aggregates" :key="aggregate.id" class="row">
+        <label class="switch">
+          <input
+            type="checkbox"
+            role="switch"
+            :checked="!!aggregate.pinned"
+            :aria-checked="!!aggregate.pinned"
+            :aria-label="t('customAggregates.showOnDashboard', { name: aggregate.label })"
+            :data-test="`pin-${aggregate.id}`"
+            @change="$emit('toggle-pin', aggregate)"
+          />
+          <span class="switch__track" aria-hidden="true"></span>
+        </label>
+
+        <div class="row__text">
+          <span class="row__label">{{ aggregate.label }}</span>
+          <span class="row__desc">{{ describe(aggregate) }}</span>
+        </div>
+
+        <div class="row__actions">
+          <button
+            type="button"
+            class="btn-icon"
+            :aria-label="t('customAggregates.edit', { name: aggregate.label })"
+            :data-test="`edit-${aggregate.id}`"
+            @click="$emit('edit', aggregate)"
+          >
+            <i class="fas fa-pen" aria-hidden="true"></i>
+          </button>
+          <button
+            type="button"
+            class="btn-icon"
+            :aria-label="t('customAggregates.delete', { name: aggregate.label })"
+            :data-test="`delete-${aggregate.id}`"
+            @click="$emit('remove', aggregate)"
+          >
+            <i class="fas fa-trash" aria-hidden="true"></i>
+          </button>
+        </div>
+      </li>
+    </ul>
+
+    <p v-else-if="!editing" class="lead">{{ t('customAggregates.empty') }}</p>
+
+    <AggregateEditForm
+      v-if="editing"
+      :report="report"
+      :existing="edited"
+      @save="$emit('save', $event)"
+      @cancel="$emit('cancel')"
+    />
+
+    <button
+      v-else
+      type="button"
+      class="btn-secondary"
+      data-test="aggregate-new"
+      @click="$emit('create')"
+    >
+      <i class="fas fa-sliders" aria-hidden="true"></i>
+      {{ t('customAggregates.addCustom') }}
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { usePluginContext } from '@/composables/usePluginContext'
+import type { CapabilityReport } from '@/composables/useSampleCapabilities'
+import type { CustomAggregate } from '@/types/customAggregate'
+import { SAMPLE_FIELD_SPECS } from '@/types/sampleFields'
+import { toDisplay, unitOf } from '../aggregateFormat'
+import type { AggregatePreset } from '../aggregatePresets'
+import AggregateEditForm from './AggregateEditForm.vue'
+import type { Draft } from './AggregateEditForm.vue'
+
+defineProps<{
+  aggregates: CustomAggregate[]
+  suggestions: AggregatePreset[]
+  report: CapabilityReport | null
+  editing: boolean
+  edited: CustomAggregate | null
+}>()
+
+defineEmits<{
+  'add-preset': [preset: AggregatePreset]
+  'toggle-pin': [aggregate: CustomAggregate]
+  edit: [aggregate: CustomAggregate]
+  remove: [aggregate: CustomAggregate]
+  create: []
+  save: [draft: Draft]
+  cancel: []
+}>()
+
+const { t } = useI18n()
+const ctx = usePluginContext()
+
+/** The rule read back in the reader's units — see the note on the card. */
+function describe(aggregate: CustomAggregate): string {
+  const measure = t(SAMPLE_FIELD_SPECS[aggregate.measure.field].labelKey)
+  const op = t(`customAggregates.ops.${aggregate.measure.op}`)
+
+  const bands = aggregate.where.map(filter => {
+    const name = t(SAMPLE_FIELD_SPECS[filter.field].labelKey)
+    const unit = unitOf(ctx.units, filter.field)
+    const low = filter.min !== undefined ? show(filter.field, filter.min) : null
+    const high = filter.max !== undefined ? show(filter.field, filter.max) : null
+
+    if (low !== null && high !== null) return `${name} ${low}–${high} ${unit}`
+    if (low !== null) return `${name} ≥ ${low} ${unit}`
+    return `${name} < ${high} ${unit}`
+  })
+
+  return bands.length ? `${op} ${measure} — ${bands.join(', ')}` : `${op} ${measure}`
+}
+
+function show(field: CustomAggregate['measure']['field'], si: number): string {
+  return String(Math.round(toDisplay(ctx.units, field, si) * 10) / 10)
+}
+</script>
+
+<style scoped>
+.manager {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: var(--background-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+}
+
+.lead {
+  margin: 0 0 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.suggestions {
+  margin-bottom: 1rem;
+}
+
+.suggestions__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.suggestion {
+  display: inline-flex;
+  gap: 0.45rem;
+  align-items: center;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.85rem;
+  color: var(--text-color);
+  cursor: pointer;
+  background: var(--card-background);
+  border: 1px dashed var(--border-color);
+  border-radius: 999px;
+}
+
+.suggestion:hover {
+  border-color: var(--primary-color);
+  border-style: solid;
+}
+
+.suggestion__add {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 0 0 0.8rem;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+  padding: 0.55rem 0.7rem;
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+}
+
+.row__text {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.row__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.row__desc {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.row__actions {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.switch__track {
+  width: 2.2rem;
+  height: 1.2rem;
+  background: var(--border-color);
+  border-radius: 999px;
+  transition: background 0.15s ease;
+}
+
+.switch__track::after {
+  display: block;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin: 0.15rem;
+  content: '';
+  background: var(--card-background);
+  border-radius: 50%;
+  transition: transform 0.15s ease;
+}
+
+.switch input:checked + .switch__track {
+  background: var(--primary-color);
+}
+
+.switch input:checked + .switch__track::after {
+  transform: translateX(1rem);
+}
+
+.btn-secondary,
+.btn-icon {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.9rem;
+  color: var(--text-color);
+  cursor: pointer;
+  background: var(--card-background);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-sm, 6px);
+}
+</style>

--- a/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
+++ b/plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue
@@ -2,35 +2,22 @@
   <section v-if="!loading" class="section-card custom-aggregates" data-test="custom-aggregates">
     <div class="section-header">
       <h3 class="section-title">
-        <i class="fas fa-sliders" aria-hidden="true"></i>
+        <i class="fas fa-chart-line" aria-hidden="true"></i>
         {{ t('customAggregates.title') }}
       </h3>
 
-      <div class="header-actions">
-        <div v-if="aggregates.length" class="period-chips" role="group">
-          <button
-            v-for="p in PERIODS"
-            :key="p"
-            type="button"
-            class="chip"
-            :class="{ 'chip--on': period === p }"
-            :aria-pressed="period === p"
-            @click="period = p"
-          >
-            {{ t(`customAggregates.periods.${p}`) }}
-          </button>
-        </div>
-        <button
-          v-if="!editing"
-          type="button"
-          class="btn-secondary"
-          data-test="aggregate-new"
-          @click="startCreate"
-        >
-          <i class="fas fa-sliders" aria-hidden="true"></i>
-          {{ t('customAggregates.addCustom') }}
-        </button>
-      </div>
+      <button
+        type="button"
+        class="btn-icon"
+        :class="{ 'btn-icon--on': managing }"
+        :aria-expanded="managing"
+        :aria-label="t('customAggregates.manage')"
+        :title="t('customAggregates.manage')"
+        data-test="aggregate-manage"
+        @click="managing = !managing"
+      >
+        <i class="fas fa-gear" aria-hidden="true"></i>
+      </button>
     </div>
 
     <div v-if="indexing" class="indexing" data-test="aggregate-indexing">
@@ -41,109 +28,50 @@
       <p class="hint">{{ t('customAggregates.indexingHint') }}</p>
     </div>
 
-    <!-- Suggestions come before the form, and are the intended way in. The form
-         asks eight questions before producing anything, which is a lot to
-         answer before knowing what the answers are worth. -->
-    <div v-if="!editing && suggestions.length" class="suggestions" data-test="aggregate-presets">
-      <p class="suggestions__lead">{{ t('customAggregates.suggestionsLead') }}</p>
-      <ul class="suggestions__list">
-        <li v-for="preset in suggestions" :key="preset.id">
-          <button
-            type="button"
-            class="suggestion"
-            :data-test="`preset-${preset.id}`"
-            @click="addPreset(preset)"
-          >
-            <i :class="preset.icon" aria-hidden="true"></i>
-            {{ t(preset.labelKey) }}
-            <i class="fas fa-plus suggestion__add" aria-hidden="true"></i>
-          </button>
-        </li>
-      </ul>
-    </div>
-
-    <AggregateEditForm
-      v-if="editing"
+    <AggregateManager
+      v-if="managing"
+      :aggregates="aggregates"
+      :suggestions="suggestions"
       :report="report"
-      :existing="edited"
+      :editing="editing"
+      :edited="edited"
+      @add-preset="addPreset"
+      @toggle-pin="togglePin"
+      @edit="startEdit"
+      @remove="onDelete"
+      @create="startCreate"
       @save="onSave"
       @cancel="stopEditing"
     />
 
-    <!-- One card per aggregate. The figure and the rule that produced it belong
-         together: they were two separate blocks, and a pinned aggregate then
-         appeared twice on the same page, once as a number and once as a rule,
-         with nothing saying they were the same thing. -->
-    <ul v-if="ordered.length" class="cards" data-test="aggregate-cards">
-      <li v-for="aggregate in ordered" :key="aggregate.id">
-        <article class="agg" :data-test="`aggregate-card-${aggregate.id}`">
-          <header class="agg__head">
-            <i :class="aggregate.icon || 'fas fa-chart-simple'" aria-hidden="true"></i>
-            <h4 class="agg__label">{{ aggregate.label }}</h4>
-            <i
-              v-if="aggregate.pinned"
-              class="fas fa-thumbtack agg__pin"
-              :title="t('customAggregates.pinned')"
-              aria-hidden="true"
-            ></i>
-          </header>
-
-          <p class="agg__value">{{ valueOf(aggregate) }}</p>
-          <p class="agg__desc">{{ describe(aggregate) }}</p>
-
-          <footer class="agg__actions">
-            <button
-              type="button"
-              class="btn-icon"
-              :aria-label="t('customAggregates.showCurve', { name: aggregate.label })"
-              :data-test="`aggregate-curve-${aggregate.id}`"
-              @click="showCurve(aggregate)"
-            >
-              <i class="fas fa-chart-line" aria-hidden="true"></i>
-            </button>
-            <button
-              type="button"
-              class="btn-icon"
-              :aria-label="t('customAggregates.edit', { name: aggregate.label })"
-              @click="startEdit(aggregate)"
-            >
-              <i class="fas fa-pen" aria-hidden="true"></i>
-            </button>
-            <button
-              type="button"
-              class="btn-icon"
-              :aria-label="t('customAggregates.delete', { name: aggregate.label })"
-              @click="onDelete(aggregate)"
-            >
-              <i class="fas fa-trash" aria-hidden="true"></i>
-            </button>
-          </footer>
-        </article>
+    <!-- The dashboard shows what the reader chose to follow, and nothing else.
+         Everything defined lives behind the gear; showing all of it here would
+         make the page grow with every experiment rather than with every
+         decision. -->
+    <ul v-if="shown.length" class="cards" data-test="aggregate-cards">
+      <li v-for="aggregate in shown" :key="aggregate.id">
+        <AggregateCard :aggregate="aggregate" />
       </li>
     </ul>
 
-    <p v-else-if="!editing && !indexing" class="empty">{{ t('customAggregates.empty') }}</p>
+    <p v-else-if="!managing && !indexing" class="empty" data-test="aggregate-empty">
+      {{ aggregates.length ? t('customAggregates.noneShown') : t('customAggregates.empty') }}
+    </p>
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
 import { usePluginContext } from '@/composables/usePluginContext'
 import { useActivityMetricsIndex } from '@/composables/useActivityMetricsIndex'
 import type { CapabilityReport } from '@/composables/useSampleCapabilities'
 import type { Activity } from '@/types/activity'
-import type { AggregationPeriod } from '@/types/aggregation'
 import type { CustomAggregate } from '@/types/customAggregate'
-import { SAMPLE_FIELD_SPECS } from '@/types/sampleFields'
-import { periodKey } from '@/utils/dateKeys'
-import { formatValue, toDisplay, unitOf } from '../aggregateFormat'
 import { availablePresets, type AggregatePreset } from '../aggregatePresets'
-import AggregateEditForm from './AggregateEditForm.vue'
+import AggregateCard from './AggregateCard.vue'
+import AggregateManager from './AggregateManager.vue'
 import type { Draft } from './AggregateEditForm.vue'
-
-const PERIODS: AggregationPeriod[] = ['week', 'month', 'year']
 
 const props = defineProps<{
   selectedSport?: string
@@ -152,36 +80,23 @@ const props = defineProps<{
 }>()
 
 const { t } = useI18n()
-const router = useRouter()
 const ctx = usePluginContext()
 const { indexing, progress, ensureIndex } = useActivityMetricsIndex()
 
 const aggregates = ref<CustomAggregate[]>([])
 const report = ref<CapabilityReport | null>(null)
-const values = ref<Record<string, number>>({})
-const period = ref<AggregationPeriod>('month')
 const loading = ref(true)
+const managing = ref(false)
 const editing = ref(false)
 const edited = ref<CustomAggregate | null>(null)
 
 const sportScope = computed(() => props.selectedSport || undefined)
 
-/**
- * Pinned first, then by name.
- *
- * Pinning no longer decides whether an aggregate is shown — every one has its
- * card now — so what is left of it is where it sits. That is still worth
- * having: the two or three a reader actually watches should not drift down the
- * grid as they define more.
- */
-const ordered = computed(() =>
-  [...aggregates.value].sort((a, b) => {
-    if (!!a.pinned !== !!b.pinned) return a.pinned ? -1 : 1
-    return a.label.localeCompare(b.label)
-  })
+/** Pinning decides what the dashboard shows — that is all it means. */
+const shown = computed(() =>
+  aggregates.value.filter(a => a.pinned).sort((a, b) => a.label.localeCompare(b.label))
 )
 
-/** Suggestions the data supports and the reader has not already taken. */
 const suggestions = computed(() =>
   availablePresets(
     report.value,
@@ -189,74 +104,12 @@ const suggestions = computed(() =>
   )
 )
 
-/**
- * The figure of the period being read, or a plain statement that there is none.
- *
- * A card showing nothing where a number belongs reads as a bug; one saying so
- * reads as an aggregate that has not matched anything yet, which is what it is.
- */
-function valueOf(aggregate: CustomAggregate): string {
-  const value = values.value[aggregate.id]
-  return value === undefined
-    ? t('customAggregates.noValue')
-    : formatValue(ctx.units, aggregate.measure.field, value)
-}
-
 async function refresh() {
   aggregates.value = await ctx.aggregates.list()
-  await loadValues()
 }
 
 async function loadReport() {
   report.value = await ctx.aggregates.capabilities(sportScope.value)
-}
-
-/**
- * The figure of the period the reader is in, not of the last one on record.
- *
- * A tile silently showing a fortnight-old week reads as this week's.
- */
-async function loadValues() {
-  const currentKey = periodKey(new Date(), period.value)
-  const next: Record<string, number> = {}
-
-  await Promise.all(
-    aggregates.value.map(async aggregate => {
-      const records = await ctx.aggregation.getAggregated(aggregate.id, period.value)
-      const record = records.find(r => r.periodKey === currentKey)
-      if (record) next[aggregate.id] = record.value
-    })
-  )
-
-  values.value = next
-}
-
-/**
- * One line saying what the aggregate does, in the reader's own units.
- *
- * Built from the definition rather than stored beside it: a description that is
- * a second copy of the rule drifts from it the first time the rule is edited.
- */
-function describe(aggregate: CustomAggregate): string {
-  const measure = t(SAMPLE_FIELD_SPECS[aggregate.measure.field].labelKey)
-  const op = t(`customAggregates.ops.${aggregate.measure.op}`)
-
-  const bands = aggregate.where.map(filter => {
-    const name = t(SAMPLE_FIELD_SPECS[filter.field].labelKey)
-    const unit = unitOf(ctx.units, filter.field)
-    const low = filter.min !== undefined ? show(filter.field, filter.min) : null
-    const high = filter.max !== undefined ? show(filter.field, filter.max) : null
-
-    if (low !== null && high !== null) return `${name} ${low}–${high} ${unit}`
-    if (low !== null) return `${name} ≥ ${low} ${unit}`
-    return `${name} < ${high} ${unit}`
-  })
-
-  return bands.length ? `${op} ${measure} — ${bands.join(', ')}` : `${op} ${measure}`
-}
-
-function show(field: CustomAggregate['measure']['field'], si: number): string {
-  return String(Math.round(toDisplay(ctx.units, field, si) * 10) / 10)
 }
 
 /**
@@ -281,23 +134,9 @@ async function addPreset(preset: AggregatePreset) {
   await refresh()
 }
 
-/**
- * Hand the aggregate to the metric tracker, which already owns the chart and
- * its granularity and window controls.
- *
- * A link rather than a second chart here: duplicating the series engine in this
- * plugin would mean two implementations of the same bucketing, and the two
- * disagreeing about what a month holds is exactly the kind of drift the shared
- * `derived.*` refs were meant to avoid.
- */
-function showCurve(aggregate: CustomAggregate) {
-  void router.push({
-    path: '/metrics',
-    query: {
-      metric: aggregate.id,
-      ...(props.selectedSport ? { sport: props.selectedSport } : {})
-    }
-  })
+async function togglePin(aggregate: CustomAggregate) {
+  await ctx.aggregates.update(aggregate.id, { pinned: !aggregate.pinned })
+  await refresh()
 }
 
 function startCreate() {
@@ -353,10 +192,6 @@ watch(sportScope, () => {
   void loadReport()
 })
 
-watch(period, () => {
-  void loadValues()
-})
-
 onMounted(async () => {
   await Promise.all([refresh(), loadReport()])
   loading.value = false
@@ -387,159 +222,36 @@ onUnmounted(() => {
 /* The card shell itself comes from the global `.section-card`, like every
    other section of this page. */
 
-.section-title i {
-  color: var(--color-green-500);
-}
-
-.suggestions {
-  margin-bottom: 1rem;
-}
-
-.suggestions__lead {
-  margin: 0 0 0.5rem;
-  font-size: 0.85rem;
-  color: var(--text-secondary);
-}
-
-.suggestions__list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.suggestion {
-  display: inline-flex;
-  gap: 0.45rem;
-  align-items: center;
-  padding: 0.45rem 0.7rem;
-  font-size: 0.85rem;
-  color: var(--text-color);
-  cursor: pointer;
-  background: var(--background-color);
-  border: 1px dashed var(--border-color);
-  border-radius: 999px;
-}
-
-.suggestion:hover {
-  border-style: solid;
-  border-color: var(--primary-color);
-}
-
-.suggestion__add {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-}
-
 .section-header {
   display: flex;
   flex-wrap: wrap;
+  gap: 0.6rem;
   align-items: center;
   justify-content: space-between;
-  gap: 0.6rem;
   margin-bottom: 1rem;
 }
 
 .section-title {
   display: flex;
-  align-items: center;
   gap: 0.5rem;
+  align-items: center;
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
   color: var(--text-color);
 }
 
-.header-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.period-chips {
-  display: flex;
-  gap: 0.25rem;
-}
-
-.chip {
-  padding: 0.35rem 0.6rem;
-  font-size: 0.82rem;
-  color: var(--text-secondary);
-  cursor: pointer;
-  background: var(--background-color);
-  border: 1px solid var(--border-color);
-  border-radius: 999px;
-}
-
-.chip--on {
-  color: var(--text-on-primary, #fff);
-  background: var(--primary-color);
-  border-color: var(--primary-color);
+.section-title i {
+  color: var(--color-green-500);
 }
 
 .cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
-  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fill, minmax(19rem, 1fr));
+  gap: 0.8rem;
   padding: 0;
-  margin: 0.75rem 0 0;
-  list-style: none;
-}
-
-.agg {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 0.8rem 0.9rem;
-  background: var(--card-background);
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
-}
-
-.agg__head {
-  display: flex;
-  gap: 0.45rem;
-  align-items: baseline;
-}
-
-.agg__head i {
-  color: var(--color-green-500);
-}
-
-.agg__label {
-  flex: 1;
-  min-width: 0;
   margin: 0;
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--text-color);
-}
-
-.agg__pin {
-  font-size: 0.7rem;
-  color: var(--text-secondary);
-}
-
-.agg__value {
-  margin: 0.4rem 0 0.15rem;
-  font-size: 1.35rem;
-  font-weight: 600;
-  color: var(--text-color);
-}
-
-.agg__desc {
-  flex: 1;
-  margin: 0 0 0.6rem;
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-}
-
-.agg__actions {
-  display: flex;
-  gap: 0.3rem;
+  list-style: none;
 }
 
 .indexing {
@@ -569,23 +281,16 @@ onUnmounted(() => {
   transition: width 0.2s ease;
 }
 
-
-
-
-
-
-
 .empty {
   margin: 0;
   font-size: 0.9rem;
   color: var(--text-secondary);
 }
 
-.btn-secondary,
 .btn-icon {
   display: inline-flex;
-  align-items: center;
   gap: 0.4rem;
+  align-items: center;
   padding: 0.45rem 0.7rem;
   font-size: 0.9rem;
   color: var(--text-color);
@@ -593,5 +298,11 @@ onUnmounted(() => {
   background: var(--background-color);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius-sm, 6px);
+}
+
+.btn-icon--on {
+  color: var(--text-on-primary, #fff);
+  background: var(--primary-color);
+  border-color: var(--primary-color);
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -987,6 +987,19 @@
       "descentSpeed": "Speed on descents",
       "climbPower": "Power on climbs",
       "hardEffortSpeed": "Speed at high heart rate"
+    },
+    "manage": "Manage what is shown",
+    "showOnDashboard": "Show {name} on the dashboard",
+    "noneShown": "Nothing shown yet. Open the gear to pick what you want to follow.",
+    "chartOf": "Chart of {name}",
+    "notEnoughPoints": "Not enough periods yet to draw a trend.",
+    "period": "Period",
+    "window": "Range",
+    "windows": {
+      "all": "All",
+      "12m": "12 mo",
+      "6m": "6 mo",
+      "3m": "3 mo"
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -987,6 +987,19 @@
       "descentSpeed": "Vitesse en descente",
       "climbPower": "Puissance en côte",
       "hardEffortSpeed": "Vitesse à haute fréquence cardiaque"
+    },
+    "manage": "Gérer ce qui est affiché",
+    "showOnDashboard": "Afficher {name} sur le tableau de bord",
+    "noneShown": "Rien affiché pour le moment. Ouvrez la roue dentée pour choisir ce que vous voulez suivre.",
+    "chartOf": "Courbe de {name}",
+    "notEnoughPoints": "Pas encore assez de périodes pour tracer une tendance.",
+    "period": "Période",
+    "window": "Fenêtre",
+    "windows": {
+      "all": "Tout",
+      "12m": "12 mois",
+      "6m": "6 mois",
+      "3m": "3 mois"
     }
   }
 }

--- a/tests/unit/CustomAggregatesSection.spec.ts
+++ b/tests/unit/CustomAggregatesSection.spec.ts
@@ -24,6 +24,14 @@ vi.mock('@/composables/useActivityMetricsIndex', () => ({
 
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }))
 
+// happy-dom has no 2d canvas context; the chart itself is not what this tests.
+vi.mock('chart.js/auto', () => ({
+  default: class {
+    update() {}
+    destroy() {}
+  }
+}))
+
 const CustomAggregatesSection = (
   await import('@plugins/app-extensions/Statistics/components/CustomAggregatesSection.vue')
 ).default
@@ -114,7 +122,12 @@ const render = (ctx: PluginContext, props: Record<string, unknown> = {}) =>
     global: { plugins: [i18n], provide: { [PLUGIN_CONTEXT_KEY]: ctx } }
   })
 
-describe('CustomAggregatesSection', () => {
+async function open(wrapper: ReturnType<typeof render>) {
+  await wrapper.find('[data-test="aggregate-manage"]').trigger('click')
+  await flushPromises()
+}
+
+describe('CustomAggregatesSection — the dashboard', () => {
   beforeEach(() => {
     setUnitSystem('metric')
     ensureIndex.mockClear()
@@ -123,65 +136,57 @@ describe('CustomAggregatesSection', () => {
     progress.value = 0
   })
 
-  it('says what it is for when nothing has been defined', async () => {
-    const wrapper = render(context())
-    await flushPromises()
-
-    expect(wrapper.find('[data-test="custom-aggregates"]').exists()).toBe(true)
-    expect(wrapper.text()).toContain('Nothing followed yet')
-    expect(wrapper.find('[data-test="aggregate-new"]').exists()).toBe(true)
-  })
-
   /**
-   * One card per aggregate, figure included. The figure and the rule behind it
-   * used to live in two separate blocks, so a pinned aggregate appeared twice
-   * on the same page with nothing saying it was the same thing.
+   * Pinning means one thing now: this is what the dashboard shows. Everything
+   * else lives behind the gear, so the page grows with decisions rather than
+   * with experiments.
    */
-  it('gives every aggregate one card carrying its figure of the current period', async () => {
-    const wrapper = render(context({ aggregates: [aggregate({ pinned: false })] }))
-    await flushPromises()
-
-    const cards = wrapper.findAll('[data-test="aggregate-cards"] .agg')
-    expect(cards).toHaveLength(1)
-    expect(cards[0].text()).toContain('Climb heart rate')
-    expect(cards[0].find('.agg__value').text()).toContain('152')
-  })
-
-  it('says so plainly on a card with no figure yet', async () => {
-    const ctx = context({ aggregates: [aggregate()] })
-    ;(ctx.aggregation.getAggregated as unknown as { mockResolvedValue: (v: unknown) => void })
-      .mockResolvedValue([])
-
-    const wrapper = render(ctx)
-    await flushPromises()
-
-    expect(wrapper.find('.agg__value').text()).toContain('No data')
-  })
-
-  it('puts the pinned ones first, since pinning now decides rank rather than presence', async () => {
+  it('shows a card for a pinned aggregate and nothing for the others', async () => {
     const wrapper = render(
       context({
         aggregates: [
-          aggregate({ id: 'plain', label: 'AAA plain', pinned: false }),
-          aggregate({ id: 'pin', label: 'ZZZ pinned', pinned: true })
+          aggregate({ id: 'shown', label: 'Shown', pinned: true }),
+          aggregate({ id: 'hidden', label: 'Hidden', pinned: false })
         ]
       })
     )
     await flushPromises()
 
-    const labels = wrapper.findAll('.agg__label').map(el => el.text())
-    expect(labels).toEqual(['ZZZ pinned', 'AAA plain'])
+    expect(wrapper.find('[data-test="aggregate-card-shown"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="aggregate-card-hidden"]').exists()).toBe(false)
   })
 
-  /** Reading the rule back, in the reader's units — a slope stored as a ratio. */
-  it('describes what an aggregate does without re-storing the description', async () => {
+  it('points at the gear when nothing is shown but something is defined', async () => {
+    const wrapper = render(context({ aggregates: [aggregate({ pinned: false })] }))
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="aggregate-empty"]').text()).toContain('Nothing shown yet')
+  })
+
+  it('says what it is for when nothing has been defined at all', async () => {
+    const wrapper = render(context())
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="aggregate-empty"]').text()).toContain('Nothing followed yet')
+  })
+
+  it('keeps the management panel closed until the gear is used', async () => {
     const wrapper = render(context({ aggregates: [aggregate()] }))
     await flushPromises()
 
-    const description = wrapper.find('.agg__desc').text()
-    expect(description).toContain('Average')
-    expect(description).toContain('Heart rate')
-    expect(description).toContain('2–10 %')
+    expect(wrapper.find('[data-test="aggregate-manager"]').exists()).toBe(false)
+    await open(wrapper)
+    expect(wrapper.find('[data-test="aggregate-manager"]').exists()).toBe(true)
+  })
+
+  it('shows progress while the scan runs', async () => {
+    indexing.value = true
+    progress.value = 42
+
+    const wrapper = render(context())
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="aggregate-indexing"]').text()).toContain('42%')
   })
 
   /**
@@ -202,39 +207,15 @@ describe('CustomAggregatesSection', () => {
     expect(ensureIndex).not.toHaveBeenCalled()
   })
 
-  it('shows progress while the scan runs', async () => {
-    indexing.value = true
-    progress.value = 42
-
-    const wrapper = render(context())
-    await flushPromises()
-
-    const banner = wrapper.find('[data-test="aggregate-indexing"]')
-    expect(banner.exists()).toBe(true)
-    expect(banner.text()).toContain('42%')
-  })
-
   it('has nothing to scan when the page holds no activity', async () => {
     render(context({ report: measuredReport(false) }), { activities: [] })
     await flushPromises()
 
     expect(ensureIndex).not.toHaveBeenCalled()
   })
-
-  it('reindexes after a definition is deleted, so its values stop being shown', async () => {
-    const ctx = context({ aggregates: [aggregate({ pinned: true })] })
-    const wrapper = render(ctx)
-    await flushPromises()
-
-    await wrapper.find('.agg__actions .btn-icon:last-child').trigger('click')
-    await flushPromises()
-
-    expect(ctx.aggregates.remove).toHaveBeenCalledWith('agg-1')
-    expect(ensureIndex).toHaveBeenCalled()
-  })
 })
 
-describe('CustomAggregatesSection — suggestions', () => {
+describe('CustomAggregatesSection — behind the gear', () => {
   beforeEach(() => {
     setUnitSystem('metric')
     ensureIndex.mockClear()
@@ -242,17 +223,12 @@ describe('CustomAggregatesSection — suggestions', () => {
     indexing.value = false
   })
 
-  /**
-   * The point of the suggestions: the form asks eight questions before it
-   * produces anything, which is a lot to answer before knowing what the answers
-   * are worth.
-   */
   it('offers ready-made aggregates the data supports', async () => {
     const wrapper = render(context({ report: measuredReport(true, ['slope', 'speed']) }))
     await flushPromises()
+    await open(wrapper)
 
     const presets = wrapper.find('[data-test="aggregate-presets"]')
-    expect(presets.exists()).toBe(true)
     expect(presets.text()).toContain('Heart rate on climbs')
     expect(presets.text()).toContain('Speed on the flat')
   })
@@ -261,39 +237,31 @@ describe('CustomAggregatesSection — suggestions', () => {
   it('withholds a suggestion whose field nothing recorded', async () => {
     const wrapper = render(context({ report: measuredReport(true, ['slope', 'speed']) }))
     await flushPromises()
+    await open(wrapper)
 
     expect(wrapper.find('[data-test="preset-climb-power"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="preset-climb-speed"]').exists()).toBe(true)
-  })
-
-  it('shows nothing at all when the data supports no suggestion', async () => {
-    const wrapper = render(context({ report: measuredReport(true) }))
-    await flushPromises()
-
-    expect(wrapper.find('[data-test="aggregate-presets"]').exists()).toBe(false)
   })
 
   it('creates from a suggestion in one click, naming it from the locale', async () => {
     const ctx = context({ report: measuredReport(true, ['slope', 'speed']) })
     const wrapper = render(ctx)
     await flushPromises()
+    await open(wrapper)
 
     await wrapper.find('[data-test="preset-climb-heart-rate"]').trigger('click')
     await flushPromises()
 
-    expect(ctx.aggregates.create).toHaveBeenCalledTimes(1)
     const [draft] = (ctx.aggregates.create as unknown as { mock: { calls: [CustomAggregate][] } })
       .mock.calls[0]
 
     expect(draft.label).toBe('Heart rate on climbs')
     expect(draft.presetId).toBe('climb-heart-rate')
-    expect(draft.measure).toEqual({ field: 'heartRate', op: 'avg' })
     // A slope is stored as the ratio it is, never as a percentage.
     expect(draft.where[0]).toEqual({ field: 'slope', min: 0.03 })
     expect(ensureIndex).toHaveBeenCalled()
   })
 
-  /** Offering it twice would create a duplicate computing exactly the same thing. */
   it('stops offering a suggestion already taken', async () => {
     const wrapper = render(
       context({
@@ -302,29 +270,68 @@ describe('CustomAggregatesSection — suggestions', () => {
       })
     )
     await flushPromises()
+    await open(wrapper)
 
     expect(wrapper.find('[data-test="preset-climb-heart-rate"]').exists()).toBe(false)
     expect(wrapper.find('[data-test="preset-flat-speed"]').exists()).toBe(true)
   })
 
-  it('hands an aggregate to the tracker, which owns the chart and its windows', async () => {
-    const wrapper = render(context({ aggregates: [aggregate()] }))
+  it('puts an aggregate on the dashboard with its switch', async () => {
+    const ctx = context({ aggregates: [aggregate({ pinned: false })] })
+    const wrapper = render(ctx)
+    await flushPromises()
+    await open(wrapper)
+
+    await wrapper.find('[data-test="pin-agg-1"]').trigger('change')
     await flushPromises()
 
-    await wrapper.find('[data-test="aggregate-curve-agg-1"]').trigger('click')
-
-    expect(push).toHaveBeenCalledWith({ path: '/metrics', query: { metric: 'agg-1' } })
+    expect(ctx.aggregates.update).toHaveBeenCalledWith('agg-1', { pinned: true })
   })
 
-  it('carries the sport filter into the curve', async () => {
-    const wrapper = render(context({ aggregates: [aggregate()] }), { selectedSport: 'running' })
+  it('takes it back off with the same switch', async () => {
+    const ctx = context({ aggregates: [aggregate({ pinned: true })] })
+    const wrapper = render(ctx)
+    await flushPromises()
+    await open(wrapper)
+
+    await wrapper.find('[data-test="pin-agg-1"]').trigger('change')
     await flushPromises()
 
-    await wrapper.find('[data-test="aggregate-curve-agg-1"]').trigger('click')
+    expect(ctx.aggregates.update).toHaveBeenCalledWith('agg-1', { pinned: false })
+  })
 
-    expect(push).toHaveBeenCalledWith({
-      path: '/metrics',
-      query: { metric: 'agg-1', sport: 'running' }
-    })
+  /** Reading the rule back, in the reader's units — a slope stored as a ratio. */
+  it('describes what an aggregate does without re-storing the description', async () => {
+    const wrapper = render(context({ aggregates: [aggregate()] }))
+    await flushPromises()
+    await open(wrapper)
+
+    const description = wrapper.find('.row__desc').text()
+    expect(description).toContain('Average')
+    expect(description).toContain('Heart rate')
+    expect(description).toContain('2–10 %')
+  })
+
+  it('reindexes after a definition is deleted, so its values stop being shown', async () => {
+    const ctx = context({ aggregates: [aggregate()] })
+    const wrapper = render(ctx)
+    await flushPromises()
+    await open(wrapper)
+
+    await wrapper.find('[data-test="delete-agg-1"]').trigger('click')
+    await flushPromises()
+
+    expect(ctx.aggregates.remove).toHaveBeenCalledWith('agg-1')
+    expect(ensureIndex).toHaveBeenCalled()
+  })
+
+  it('opens the form only when asked', async () => {
+    const wrapper = render(context({ report: measuredReport(true, ['slope', 'speed']) }))
+    await flushPromises()
+    await open(wrapper)
+
+    expect(wrapper.find('[data-test="aggregate-label"]').exists()).toBe(false)
+    await wrapper.find('[data-test="aggregate-new"]').trigger('click')
+    expect(wrapper.find('[data-test="aggregate-label"]').exists()).toBe(true)
   })
 })

--- a/tests/unit/aggregateSeries.spec.ts
+++ b/tests/unit/aggregateSeries.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import {
+  availableWindows,
+  buildSeries,
+  type WindowId
+} from '@plugins/app-extensions/Statistics/aggregateSeries'
+import type { AggregatedRecord, AggregationPeriod } from '@/types/aggregation'
+
+function record(periodType: AggregationPeriod, key: string, value: number): AggregatedRecord {
+  return {
+    id: `agg|${periodType}|${key}`,
+    metricId: 'agg',
+    periodType,
+    periodKey: key,
+    value,
+    sum: value,
+    count: 1,
+    lastUpdated: 0
+  }
+}
+
+describe('availableWindows', () => {
+  it('offers ranges on weekly and monthly cards', () => {
+    expect(availableWindows('week')).toContain('3m')
+    expect(availableWindows('month')).toContain('12m')
+    expect(availableWindows('month')).toContain('all')
+  })
+
+  /** Three months of yearly buckets is one point, and one point is not a chart. */
+  it('offers none on a yearly card', () => {
+    expect(availableWindows('year')).toEqual([])
+  })
+})
+
+describe('buildSeries', () => {
+  const months = [
+    record('month', '2026-03', 3),
+    record('month', '2026-01', 1),
+    record('month', '2026-02', 2)
+  ]
+
+  it('orders points oldest first, whatever order the store held them in', () => {
+    expect(buildSeries(months, 'month', 'all').map(p => p.key)).toEqual([
+      '2026-01',
+      '2026-02',
+      '2026-03'
+    ])
+  })
+
+  it('ignores the records of another period', () => {
+    const mixed = [...months, record('week', '2026-W05', 9), record('year', '2026', 42)]
+
+    expect(buildSeries(mixed, 'month', 'all')).toHaveLength(3)
+  })
+
+  /** A chart must end on the period being read, not on whatever came last. */
+  it('keeps the tail when a window narrows the range', () => {
+    const year = Array.from({ length: 12 }, (_, i) =>
+      record('month', `2026-${String(i + 1).padStart(2, '0')}`, i)
+    )
+
+    const quarter = buildSeries(year, 'month', '3m')
+
+    expect(quarter.map(p => p.key)).toEqual(['2026-10', '2026-11', '2026-12'])
+  })
+
+  it('sorts ISO week keys by week rather than alphabetically by accident', () => {
+    const weeks = [
+      record('week', '2026-W30', 30),
+      record('week', '2026-W05', 5),
+      record('week', '2026-W12', 12)
+    ]
+
+    expect(buildSeries(weeks, 'week', 'all').map(p => p.value)).toEqual([5, 12, 30])
+  })
+
+  it('drops a record whose value never landed', () => {
+    const broken = [...months, record('month', '2026-04', Number.NaN)]
+
+    expect(buildSeries(broken, 'month', 'all')).toHaveLength(3)
+  })
+
+  it('has nothing to plot from nothing', () => {
+    expect(buildSeries([], 'month', 'all')).toEqual([])
+  })
+
+  it('leaves an unbounded window untouched', () => {
+    const window: WindowId = 'all'
+    expect(buildSeries(months, 'month', window)).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
Suite de #95, à l'usage. Deux changements de fond sur la section « Mes agrégats » du tableau de bord.

## L'épinglage veut dire une seule chose

**Ce que le tableau de bord affiche.** Un agrégat épinglé a sa card, les autres n'apparaissent pas. La version précédente avait dérivé vers « ça décide du rang », ce qui ne voulait plus dire grand-chose et faisait grossir la page à chaque définition.

Tout le reste passe derrière une **roue dentée** dans l'en-tête de la section : les suggestions, la liste complète avec un interrupteur par agrégat, l'édition, la suppression, le formulaire de création. La page grandit désormais avec les décisions plutôt qu'avec les essais.

## Chaque card porte sa courbe

Une card épinglée est complète : le chiffre de la période, la règle qui l'a produit, **sa propre courbe**, et ses contrôles de période (semaine / mois / année) et de fenêtre (3 / 6 / 12 mois / tout).

C'était un lien vers le Metric Tracker, ce qui obligeait à quitter la page pour voir la forme d'un chiffre qui était juste là.

## La courbe n'a demandé aucun moteur de séries

`buildAggregateRecords` avait déjà replié les valeurs en enregistrements semaine, mois et année. Tracer revient donc à les lire dans l'ordre des clés et à garder la queue que la fenêtre demande. Le découpage en périodes reste à un seul endroit, et aucune seconde implémentation ne peut diverger de la première sur ce qu'est une semaine.

Chart.js est appelé directement, comme les deux autres graphes de ce plugin le font déjà, plutôt que d'importer un composant d'un autre plugin — ce qui aurait été le premier import inter-plugins du dépôt.

Deux détails d'échelle :

- Une card annuelle n'offre pas de fenêtre : trois mois de buckets annuels font un point, et un point n'est pas une courbe.
- L'axe Y ne part pas de zéro. Ce sont des moyennes à l'intérieur d'une bande, et un axe de fréquence cardiaque partant de zéro écrase toute variation qui mérite d'être regardée.

## Vérifications

- `npm run typecheck` (vue-tsc) : clean
- `npm run test:unit` : **983 passés**
- `npm run lint` : 0 erreur (6 warnings préexistants)

Le spec de la section a été réécrit — il visait l'ancienne structure — et un spec est ajouté sur les séries : l'ordre des clés ISO de semaine, la queue conservée par une fenêtre, l'absence de fenêtre en annuel.

## Ce qui n'a pas été vérifié

Le rendu, comme pour #93 et #95 : ni navigateur utilisable ni binaire Cypress installable ici. Et cette fois l'enjeu est plus grand, parce qu'il y a un vrai graphe à l'écran — hauteur de la courbe dans la card, lisibilité des étiquettes de semaine sur douze points, et tenue de la grille en mobile où une card fait 19 rem de large minimum.

## Reste ouvert

Le panneau ne pilote que les agrégats. L'étendre aux sections natives — résumé, calendrier, tendances, records — demande de rendre leur affichage configurable, ce qui est un autre chantier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaTtfq1vFkgSWSgeabzwjv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaTtfq1vFkgSWSgeabzwjv)_