### PR TITLE
fix(garmin): keep the samples a summary push does not carry

### DIFF
--- a/plugins/data-providers/GarminProvider/client/GarminSyncManager.ts
+++ b/plugins/data-providers/GarminProvider/client/GarminSyncManager.ts
@@ -1,8 +1,15 @@
 // plugins/data-providers/GarminProvider/client/GarminSyncManager.ts
 import { getTokens, getSyncState, updateSyncState } from './storage'
-import { adaptGarminSummary, adaptGarminDetails } from './adapter'
+import {
+  adaptGarminSummary,
+  adaptGarminDetails,
+  isActivityPayload,
+  mergeGarminActivity,
+  mergeGarminDetails
+} from './adapter'
 import { getValidAccessToken } from './garminAuth'
 import { getPluginContext } from '@/services/PluginContextFactory'
+import type { Activity, ActivityDetails } from '@/types/activity'
 import pluginEnv from './env'
 
 const proxyUrl = pluginEnv.proxyUrl
@@ -261,11 +268,40 @@ export class GarminSyncManager {
 
     console.log('[GarminSync] Daily refresh: polling for push data')
 
-    const count = await this.pollAndConsumeCallbacks(1) // single attempt, no retry
+    // Ids, not saves: one outing is pushed twice (summary, then details), and
+    // it is also the one the pull below completes. Counting rows would report
+    // three activities for one run.
+    const seen = new Set<string>()
+    await this.pollAndConsumeCallbacks(1, seen) // single attempt, no retry
+    await this.fetchRecentDetails(seen)
     await updateSyncState({ lastSyncDate: Date.now() })
 
-    console.log(`[GarminSync] Daily refresh complete: ${count} activities`)
-    return count
+    console.log(`[GarminSync] Daily refresh complete: ${seen.size} activities`)
+    return seen.size
+  }
+
+  /**
+   * Pull the details for everything uploaded in the last 24 h.
+   *
+   * The push buffer alone is not enough to answer a refresh: Garmin sends the
+   * activity *summary* as soon as the watch syncs, but the *details* — the
+   * samples the map and the graphs are drawn from — only once it has processed
+   * the FIT file, minutes later. Refreshing in between used to leave the card
+   * on the feed with nothing in it until the next refresh.
+   *
+   * Best effort: the push data has already been saved when this runs, so a
+   * failure here must not fail the refresh.
+   */
+  private async fetchRecentDetails(collector: Set<string>): Promise<void> {
+    const end = new Date()
+    // Garmin caps the pull endpoints at a 24 h window.
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+
+    try {
+      await this.fetchAndSaveActivities(start, end, false, 0, collector)
+    } catch (err) {
+      console.warn('[GarminSync] Could not pull recent activity details:', err)
+    }
   }
 
   /**
@@ -324,11 +360,12 @@ export class GarminSyncManager {
     startDate: Date,
     endDate: Date,
     useBackfill: boolean,
-    retryCount = 0
+    retryCount = 0,
+    /** Ids saved so far, when the caller counts distinct activities. */
+    collector?: Set<string>
   ): Promise<number> {
     const MAX_RETRIES = 3
     const accessToken = await getValidAccessToken()
-    const ctx = await getPluginContext()
 
     const startSeconds = Math.floor(startDate.getTime() / 1000)
     const endSeconds = Math.floor(endDate.getTime() / 1000)
@@ -352,7 +389,13 @@ export class GarminSyncManager {
           `[GarminSync] Rate limit hit, retrying in ${backoffMs / 1000}s (attempt ${retryCount + 1}/${MAX_RETRIES})`
         )
         await this.sleep(backoffMs)
-        return this.fetchAndSaveActivities(startDate, endDate, useBackfill, retryCount + 1)
+        return this.fetchAndSaveActivities(
+          startDate,
+          endDate,
+          useBackfill,
+          retryCount + 1,
+          collector
+        )
       }
     }
 
@@ -362,7 +405,7 @@ export class GarminSyncManager {
       // 409 = duplicate backfill already processed, poll callbacks from ping notifications
       if (res.status === 409 && errorBody.includes('duplicate backfill')) {
         console.log('[GarminSync] Backfill already done, polling callbacks')
-        return this.pollAndConsumeCallbacks()
+        return this.pollAndConsumeCallbacks(3, collector)
       }
 
       // 403 = user didn't grant HISTORICAL_DATA_EXPORT — skip this range gracefully.
@@ -390,7 +433,13 @@ export class GarminSyncManager {
             `[GarminSync] Rate limit in response, retrying in ${backoffMs / 1000}s (attempt ${retryCount + 1}/${MAX_RETRIES})`
           )
           await this.sleep(backoffMs)
-          return this.fetchAndSaveActivities(startDate, endDate, useBackfill, retryCount + 1)
+          return this.fetchAndSaveActivities(
+            startDate,
+            endDate,
+            useBackfill,
+            retryCount + 1,
+            collector
+          )
         }
       }
       throw new Error(`Garmin API error: ${res.status} - ${errorBody.substring(0, 200)}`)
@@ -404,7 +453,7 @@ export class GarminSyncManager {
     if (useBackfill && (res.status === 202 || !text || text.trim() === '')) {
       console.log('[GarminSync] Backfill accepted (async), polling push data...')
       await this.sleep(5000)
-      return this.pollAndConsumeCallbacks(5)
+      return this.pollAndConsumeCallbacks(5, collector)
     }
 
     if (!text || text.trim() === '') return 0
@@ -413,17 +462,67 @@ export class GarminSyncManager {
 
     if (!Array.isArray(raw) || raw.length === 0) {
       // Backfill may also acknowledge with an empty array; data still comes via push.
-      if (useBackfill) return this.pollAndConsumeCallbacks(5)
+      if (useBackfill) return this.pollAndConsumeCallbacks(5, collector)
       return 0
     }
 
-    const summaries = raw.map(adaptGarminSummary)
-    const details = raw.map(adaptGarminDetails)
+    const saved = await this.saveRawActivities(raw, collector)
+
+    return saved.length
+  }
+
+  /**
+   * Adapt raw Garmin payloads and fold them into what is already stored.
+   *
+   * Garmin sends the same outing twice — an activity summary as soon as the
+   * watch syncs, then the activity details with the samples once the FIT file
+   * is processed — and the two can arrive in either order, in either direction
+   * of the same batch. Writing them straight through meant whichever landed
+   * last won, so a summary push regularly erased a track that was already
+   * there: the activity stayed in the feed with an empty map.
+   *
+   * Returns the ids actually written, so both halves of one outing count once.
+   */
+  private async saveRawActivities(raw: unknown[], collector?: Set<string>): Promise<string[]> {
+    const ctx = await getPluginContext()
+    const payloads = raw.filter(isActivityPayload)
+
+    if (payloads.length < raw.length) {
+      console.warn(
+        `[GarminSync] Ignoring ${raw.length - payloads.length} payload(s) that are not activities`
+      )
+    }
+    if (payloads.length === 0) return []
+
+    // Collapse a batch that carries both halves of the same activity.
+    const byId = new Map<string, { activity: Activity; details: ActivityDetails }>()
+    for (const payload of payloads) {
+      const activity = adaptGarminSummary(payload)
+      const details = adaptGarminDetails(payload)
+      const seen = byId.get(activity.id)
+      byId.set(activity.id, {
+        activity: mergeGarminActivity(seen?.activity, activity),
+        details: mergeGarminDetails(seen?.details, details)
+      })
+    }
+
+    const activities: Activity[] = []
+    const detailsList: ActivityDetails[] = []
+    for (const [id, entry] of byId) {
+      const [storedActivity, storedDetails] = await Promise.all([
+        ctx.activity.getActivity(id),
+        ctx.activity.getDetails(id)
+      ])
+      activities.push(mergeGarminActivity(storedActivity, entry.activity))
+      detailsList.push(mergeGarminDetails(storedDetails, entry.details))
+    }
 
     // Atomic transaction: both succeed or both fail
-    await ctx.activity.saveActivitiesWithDetails(summaries, details)
+    await ctx.activity.saveActivitiesWithDetails(activities, detailsList)
 
-    return summaries.length
+    const ids = [...byId.keys()]
+    ids.forEach(id => collector?.add(id))
+    return ids
   }
 
   /**
@@ -436,9 +535,10 @@ export class GarminSyncManager {
    * Retries up to `maxRetries` times with a 5s delay when no data is buffered yet
    * (Garmin's backfill push is asynchronous).
    */
-  private async pollAndConsumeCallbacks(maxRetries = 3): Promise<number> {
-    const ctx = await getPluginContext()
-    let totalCount = 0
+  private async pollAndConsumeCallbacks(maxRetries = 3, collector?: Set<string>): Promise<number> {
+    // Ids, not entries: Garmin buffers a summary push and a details push for
+    // the same outing, and announcing "2 new activities" for one run is wrong.
+    const savedIds = collector ?? new Set<string>()
     let waited = 0
     const MAX_DRAIN_BATCHES = 500 // safety cap against an unexpected infinite loop
 
@@ -451,17 +551,17 @@ export class GarminSyncManager {
 
       if (res.status === 401) {
         console.warn('[GarminSync] Unauthorized when reading push buffer')
-        return totalCount
+        return savedIds.size
       }
       if (!res.ok) {
         console.warn(`[GarminSync] Failed to fetch push data: ${res.status}`)
-        return totalCount
+        return savedIds.size
       }
 
       const entries = await res.json()
       if (!Array.isArray(entries) || entries.length === 0) {
         // Buffer empty. If we already drained some, we're done.
-        if (totalCount > 0) break
+        if (savedIds.size > 0) break
         // Otherwise wait for Garmin's async backfill push to land.
         if (waited < maxRetries - 1) {
           waited++
@@ -483,10 +583,7 @@ export class GarminSyncManager {
 
           // Push data: activity object directly (ownership already enforced server-side)
           const items = Array.isArray(raw) ? raw : [raw]
-          const summaries = items.map(adaptGarminSummary)
-          const details = items.map(adaptGarminDetails)
-          await ctx.activity.saveActivitiesWithDetails(summaries, details)
-          totalCount += summaries.length
+          await this.saveRawActivities(items, savedIds)
 
           consumedFiles.push(entry.name)
         } catch (err) {
@@ -511,7 +608,7 @@ export class GarminSyncManager {
       }
     }
 
-    return totalCount
+    return savedIds.size
   }
 
   /**

--- a/plugins/data-providers/GarminProvider/client/adapter.ts
+++ b/plugins/data-providers/GarminProvider/client/adapter.ts
@@ -10,9 +10,53 @@ interface GarminRawActivity extends RawRecord {
   activityId?: string
 }
 
+/**
+ * Garmin pushes the same activity under two different shapes, and the push
+ * buffer can hand us either one first:
+ *
+ * - **activity summary** — every field flat at the top level, no `samples`.
+ *   Sent as soon as the watch syncs.
+ * - **activity details** — the same fields nested under `summary`, plus the
+ *   `samples` time series. Sent later, once Garmin has processed the FIT file.
+ *
+ * Reading only `raw.summary` meant a summary push produced an ActivityDetails
+ * with no samples *and* no stats, which then overwrote a details push that had
+ * already landed: the activity showed up but its map and graphs were empty.
+ */
+function summaryOf(raw: GarminRawActivity): RawRecord {
+  return (raw.summary as RawRecord | undefined) ?? raw
+}
+
+/**
+ * The activity id, wherever this payload happens to carry it.
+ *
+ * Summary and details must resolve to the *same* id — they are two halves of
+ * one record. The details payload names it at the top level, the summary
+ * payload inside the summary object.
+ */
+function activityIdOf(raw: GarminRawActivity): string | undefined {
+  const summary = summaryOf(raw)
+  const id = raw.activityId ?? summary.activityId ?? raw.summaryId ?? summary.summaryId
+  return id != null ? String(id) : undefined
+}
+
+/**
+ * True when the payload carries something worth storing as an activity.
+ *
+ * The push buffer is shared with Garmin's other webhooks (dailies, sleeps…);
+ * without this, one of those would be adapted into a `garmin_undefined`
+ * activity with no date and no distance.
+ */
+export function isActivityPayload(raw: unknown): raw is GarminRawActivity {
+  if (!raw || typeof raw !== 'object') return false
+  const candidate = raw as GarminRawActivity
+  if (activityIdOf(candidate) === undefined) return false
+  return typeof summaryOf(candidate).startTimeInSeconds === 'number'
+}
+
 // Résumé d'activité Garmin → Activity OpenStride
 export function adaptGarminSummary(garminDetails: GarminRawActivity): Activity {
-  const garmin = garminDetails.summary || garminDetails
+  const garmin = summaryOf(garminDetails)
 
   const samples = garminDetails.samples ?? []
   const polyline: [number, number][] = []
@@ -24,14 +68,16 @@ export function adaptGarminSummary(garminDetails: GarminRawActivity): Activity {
     }
   }
   return {
-    id: `garmin_${garmin.activityId}`,
+    id: `garmin_${activityIdOf(garminDetails)}`,
     provider: 'garmin',
     startTime: garmin.startTimeInSeconds as number,
     duration: garmin.durationInSeconds as number,
     distance: garmin.distanceInMeters as number,
     type: mapGarminSport(garmin.activityType),
     title: garmin.activityName as string,
-    mapPolyline: polyline,
+    // Left undefined rather than empty: a summary push has no track, and an
+    // empty array would erase the one a details push already stored.
+    mapPolyline: polyline.length > 0 ? polyline : undefined,
     version: 1,
     lastModified: Date.now()
   }
@@ -39,7 +85,8 @@ export function adaptGarminSummary(garminDetails: GarminRawActivity): Activity {
 
 // Détail Garmin → ActivityDetails OpenStride
 export function adaptGarminDetails(garmin: GarminRawActivity): ActivityDetails {
-  const start = (garmin.summary?.startTimeInSeconds as number) ?? 0
+  const summary = summaryOf(garmin)
+  const start = (summary.startTimeInSeconds as number) ?? 0
   // const metrics = garmin.activityDetailMetrics?.metrics ?? []
   const samples = garmin.samples?.map((m: RawRecord) => ({
     time: (m.startTimeInSeconds as number) - start,
@@ -64,7 +111,6 @@ export function adaptGarminDetails(garmin: GarminRawActivity): ActivityDetails {
     distance: (lap.totalDistanceInMeters as number) || 0
   }))
 
-  const summary = garmin.summary ?? {}
   const num = (v: unknown): number | undefined =>
     typeof v === 'number' && Number.isFinite(v) ? v : undefined
 
@@ -85,7 +131,7 @@ export function adaptGarminDetails(garmin: GarminRawActivity): ActivityDetails {
   record('swim.swolf', num(summary.averageSwolf), 'swolf')
 
   return {
-    id: `garmin_${garmin.activityId}`,
+    id: `garmin_${activityIdOf(garmin)}`,
     samples,
     laps,
     measurements: Object.keys(measurements).length > 0 ? measurements : undefined,
@@ -106,5 +152,49 @@ export function adaptGarminDetails(garmin: GarminRawActivity): ActivityDetails {
     },
     version: 1,
     lastModified: Date.now()
+  }
+}
+
+/** Incoming values win, but only where the payload actually carries one. */
+function mergeDefined<T extends object>(stored: T | undefined, incoming: T | undefined): T {
+  if (!stored) return incoming as T
+  if (!incoming) return stored
+  const out = { ...stored } as Record<string, unknown>
+  for (const [key, value] of Object.entries(incoming)) {
+    if (value !== undefined) out[key] = value
+  }
+  return out as T
+}
+
+/**
+ * Fold a freshly pushed activity into the one already stored.
+ *
+ * The two pushes describe the same outing, so the second one to arrive must
+ * complete the record rather than replace it — whichever order they land in.
+ */
+export function mergeGarminActivity(stored: Activity | undefined, incoming: Activity): Activity {
+  if (!stored) return incoming
+  return {
+    ...mergeDefined(stored, incoming),
+    version: Math.max(stored.version ?? 0, incoming.version ?? 0)
+  }
+}
+
+/** Same as `mergeGarminActivity`, for the details half of the record. */
+export function mergeGarminDetails(
+  stored: ActivityDetails | undefined,
+  incoming: ActivityDetails
+): ActivityDetails {
+  if (!stored) return incoming
+  return {
+    ...mergeDefined(stored, incoming),
+    // A summary push carries no time series; keeping the stored one is the
+    // whole point of merging instead of putting.
+    samples: incoming.samples?.length ? incoming.samples : stored.samples,
+    laps: incoming.laps?.length ? incoming.laps : stored.laps,
+    measurements: mergeDefined(stored.measurements, incoming.measurements),
+    stats: mergeDefined(stored.stats, incoming.stats),
+    version: Math.max(stored.version ?? 0, incoming.version ?? 0),
+    lastModified: incoming.lastModified
   }
 }

--- a/tests/unit/GarminSyncManager.spec.ts
+++ b/tests/unit/GarminSyncManager.spec.ts
@@ -40,13 +40,24 @@ vi.mock('../../plugins/data-providers/GarminProvider/client/env', () => ({
   default: { proxyUrl: 'https://proxy.test.com' }
 }))
 
-// Mock PluginContext
-const mockSaveActivitiesWithDetails = vi.fn()
+// Mock PluginContext — backed by a tiny in-memory store, because the sync
+// manager now reads what is already saved before writing over it.
+const savedActivities = new Map<string, any>()
+const savedDetails = new Map<string, any>()
+const mockSaveActivitiesWithDetails = vi.fn((activities: any[], details: any[]) => {
+  activities.forEach((a, i) => {
+    savedActivities.set(a.id, a)
+    savedDetails.set(details[i].id, details[i])
+  })
+  return Promise.resolve()
+})
 vi.mock('@/services/PluginContextFactory', () => ({
   getPluginContext: vi.fn(() =>
     Promise.resolve({
       activity: {
-        saveActivitiesWithDetails: mockSaveActivitiesWithDetails
+        saveActivitiesWithDetails: mockSaveActivitiesWithDetails,
+        getActivity: (id: string) => Promise.resolve(savedActivities.get(id)),
+        getDetails: (id: string) => Promise.resolve(savedDetails.get(id))
       }
     })
   )
@@ -105,12 +116,27 @@ function garminActivity(i: number) {
   }
 }
 
+/**
+ * Garmin's *other* push shape for the same outing: the activity summary, whose
+ * fields sit flat at the top level with no `samples` and no `summary` wrapper.
+ * It lands as soon as the watch syncs, before the FIT file is processed.
+ */
+function garminSummaryPush(i: number) {
+  const { summary } = garminActivity(i)
+  return { ...summary, activeKilocalories: 420 }
+}
+
 /** A /push buffer listing: [{ name, data }] where data is a raw Garmin activity */
 function pushBuffer(count: number) {
   return Array.from({ length: count }, (_, i) => {
     const a = garminActivity(i)
     return { name: `garmin_push/u1/activityDetails_${a.activityId}.json`, data: a }
   })
+}
+
+/** One /push entry, named the way the proxy names it for that payload type */
+function pushEntry(type: 'activities' | 'activityDetails', data: any) {
+  return { name: `garmin_push/u1/${type}_${data.activityId}.json`, data }
 }
 
 function okJsonResponse(data: any) {
@@ -140,10 +166,11 @@ describe('GarminSyncManager', () => {
     vi.clearAllMocks()
     vi.useFakeTimers({ shouldAdvanceTime: true })
     mockSyncState = {}
+    savedActivities.clear()
+    savedDetails.clear()
     // Reset singleton
     ;(GarminSyncManager as any).instance = null
     manager = GarminSyncManager.getInstance()
-    mockSaveActivitiesWithDetails.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -181,9 +208,7 @@ describe('GarminSyncManager', () => {
       )
 
       // Consumed files are deleted via authenticated POST /push/consume
-      const consumeCall = mockFetch.mock.calls.find(c =>
-        (c[0] as string).endsWith('/push/consume')
-      )
+      const consumeCall = mockFetch.mock.calls.find(c => (c[0] as string).endsWith('/push/consume'))
       expect(consumeCall).toBeTruthy()
       const consumeOpts = consumeCall![1] as RequestInit
       expect(consumeOpts.method).toBe('POST')
@@ -191,6 +216,157 @@ describe('GarminSyncManager', () => {
         expect.objectContaining({ Authorization: 'Bearer test-access-token' })
       )
       expect(JSON.parse(consumeOpts.body as string).files).toHaveLength(2)
+    })
+
+    it('pulls the last 24 h of details, so a refresh does not wait for the push', async () => {
+      // Only the summary has been pushed — the details push has not landed yet.
+      let pushReads = 0
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 1 }))
+        if (url.endsWith('/push')) {
+          pushReads++
+          return Promise.resolve(
+            okJsonResponse(pushReads === 1 ? [pushEntry('activities', garminSummaryPush(0))] : [])
+          )
+        }
+        // …but the pull endpoint already has them
+        if (url.includes('/api/activityDetails'))
+          return Promise.resolve(okJsonResponse([garminActivity(0)]))
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      const count = await manager.dailyRefresh()
+
+      // One outing, whichever route it came in by
+      expect(count).toBe(1)
+      expect(savedDetails.get('garmin_act-1').samples).toHaveLength(1)
+
+      // Pulled over a window Garmin accepts: 24 h, by upload time
+      const pull = mockFetch.mock.calls.find(c => (c[0] as string).includes('/api/activityDetails'))
+      expect(pull).toBeTruthy()
+      const params = new URLSearchParams((pull![0] as string).split('?')[1])
+      const span =
+        Number(params.get('uploadEndTimeInSeconds')) -
+        Number(params.get('uploadStartTimeInSeconds'))
+      expect(span).toBe(24 * 60 * 60)
+    })
+
+    it('still saves the push data when the details pull fails', async () => {
+      let pushReads = 0
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 1 }))
+        if (url.endsWith('/push')) {
+          pushReads++
+          return Promise.resolve(okJsonResponse(pushReads === 1 ? pushBuffer(1) : []))
+        }
+        if (url.includes('/api/activityDetails'))
+          return Promise.resolve(errorResponse(500, 'Garmin is down'))
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      const count = await manager.dailyRefresh()
+
+      expect(count).toBe(1)
+      expect(savedDetails.get('garmin_act-1').samples).toHaveLength(1)
+    })
+
+    it('keeps the samples when a summary push lands after the details push', async () => {
+      // Garmin sends the summary first and the details later, but the buffer
+      // can hand them over in either order — and the summary carries no track.
+      const details = garminActivity(0)
+      const buffers = [
+        [pushEntry('activityDetails', details)],
+        [pushEntry('activities', garminSummaryPush(0))],
+        []
+      ]
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 1 }))
+        if (url.endsWith('/push')) return Promise.resolve(okJsonResponse(buffers.shift() ?? []))
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      await manager.dailyRefresh() // consumes the details push
+      await manager.dailyRefresh() // consumes the summary push
+
+      const stored = savedDetails.get('garmin_act-1')
+      expect(stored.samples).toHaveLength(1)
+      expect(stored.samples[0].heartRate).toBe(140)
+      expect(savedActivities.get('garmin_act-1').mapPolyline).toHaveLength(1)
+      // …and the summary-only push still contributes what only it carries
+      expect(stored.stats.calories).toBe(420)
+    })
+
+    it('reads the stats off a summary-only push', async () => {
+      let reads = 0
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 1 }))
+        if (url.endsWith('/push')) {
+          reads++
+          return Promise.resolve(
+            okJsonResponse(reads === 1 ? [pushEntry('activities', garminSummaryPush(0))] : [])
+          )
+        }
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      const count = await manager.dailyRefresh()
+
+      expect(count).toBe(1)
+      const activity = savedActivities.get('garmin_act-1')
+      expect(activity.distance).toBe(5000)
+      expect(activity.type).toBe('running')
+      const details = savedDetails.get('garmin_act-1')
+      expect(details.stats.averageHeartRate).toBe(145)
+      expect(details.stats.calories).toBe(420)
+    })
+
+    it('counts one activity when both of its pushes are in the same batch', async () => {
+      let reads = 0
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 2 }))
+        if (url.endsWith('/push')) {
+          reads++
+          return Promise.resolve(
+            okJsonResponse(
+              reads === 1
+                ? [
+                    pushEntry('activityDetails', garminActivity(0)),
+                    pushEntry('activities', garminSummaryPush(0))
+                  ]
+                : []
+            )
+          )
+        }
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      const count = await manager.dailyRefresh()
+
+      expect(count).toBe(1)
+      expect(savedDetails.get('garmin_act-1').samples).toHaveLength(1)
+    })
+
+    it('ignores a push that is not an activity', async () => {
+      let reads = 0
+      mockFetch.mockImplementation((url: string) => {
+        if (url.endsWith('/push/consume')) return Promise.resolve(okJsonResponse({ deleted: 1 }))
+        if (url.endsWith('/push')) {
+          reads++
+          return Promise.resolve(
+            okJsonResponse(
+              reads === 1 ? [{ name: 'garmin_push/u1/dailies_1.json', data: { steps: 12000 } }] : []
+            )
+          )
+        }
+        return Promise.resolve(okJsonResponse([]))
+      })
+
+      const count = await manager.dailyRefresh()
+
+      expect(count).toBe(0)
+      expect(mockSaveActivitiesWithDetails).not.toHaveBeenCalled()
+      // Still consumed, or the buffer would never drain
+      expect(mockFetch.mock.calls.some(c => (c[0] as string).endsWith('/push/consume'))).toBe(true)
     })
 
     it('returns 0 when no tokens are available', async () => {


### PR DESCRIPTION
Un refresh depuis la home ramenait bien l'activité Garmin, mais la carte restait vide.

## La cause

Garmin envoie **deux** push pour la même sortie, et le proxy (`functions/src/index.ts`) bufferise tous les types de summary tels quels, un fichier par entrée :

| Push | Fichier | Contenu |
| --- | --- | --- |
| `activities` | `activities_<id>.json` | champs **à plat**, pas de `samples` — dès que la montre se synchronise |
| `activityDetails` | `activityDetails_<id>.json` | mêmes champs sous `summary`, **plus les `samples`** — quelques minutes plus tard, une fois le FIT traité |

`adaptGarminDetails` ne lisait que `garmin.summary` : sur un push résumé il produisait un `ActivityDetails` sans samples **et** sans stats (`summary ?? {}`). Comme `saveActivitiesWithDetails` fait un `put` sec, ce record vide écrasait les vrais détails. `adaptGarminSummary`, lui, gérait déjà les deux formes — d'où une activité correcte et une carte vide.

Le refresh consomme le push résumé et supprime le fichier ; les détails n'arrivent que plus tard, ce qui explique le côté intermittent (un second refresh « répare » souvent la sortie).

## Le correctif

- `adapter.ts` : `summaryOf()` lit les deux formes, donc un push résumé apporte au moins ses stats (FC, calories, D+/D−) ; `activityIdOf()` garantit que résumé et détails tombent sur le même id ; un `mapPolyline` vide devient `undefined` plutôt qu'un tableau vide.
- `mergeGarminActivity` / `mergeGarminDetails` : un push complète l'enregistrement au lieu de le remplacer — samples, laps, measurements et tracé survivent à un payload qui ne les porte pas, dans n'importe quel ordre d'arrivée, y compris quand les deux moitiés sont dans le même batch.
- `isActivityPayload` : les autres webhooks (dailies, sleeps…) partagent le même bucket et devenaient des activités `garmin_undefined` — ils sont ignorés, mais toujours consommés, sinon le buffer ne se vide jamais.
- `dailyRefresh` tire en plus les détails des 24 dernières heures (`/api/activityDetails?uploadStart…`, la fenêtre max autorisée par Garmin) : un refresh juste après une sortie n'attend plus le push. Best effort — si l'appel échoue, les données du push sont déjà sauvées.
- Le compte affiché (« N activités synchronisées ») compte des activités distinctes, plus des lignes écrites : une sortie valait deux ou trois.

Aucun changement côté proxy ni côté schéma IndexedDB.

## Vérification

6 nouveaux tests dans `tests/unit/GarminSyncManager.spec.ts` — le mock du `PluginContext` a maintenant un store en mémoire, puisque le manager relit avant d'écrire. Les 4 qui portent sur l'écrasement échouent sur l'ancien code et passent sur le nouveau (vérifié en stashant le diff).

- `npm run test:unit` : 989 passed, 7 skipped
- `npm run typecheck` (`vue-tsc`) : clean
- `npm run lint` : 0 error, warnings inchangées


---
_Generated by [Claude Code](https://claude.ai/code/session_01LW4x511W3qL7TssHq7ABof)_